### PR TITLE
Treat empty string as no password

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -31,6 +31,7 @@ defmodule Mariaex.Protocol do
     password = opts[:password]
     scramble = case password do
       nil -> ""
+      ""  -> ""      
       _   -> password(plugin, password, <<salt1 :: binary, salt2 :: binary>>)
     end
     msg = handshake_resp(username: :unicode.characters_to_binary(opts[:username]), password: scramble,


### PR DESCRIPTION
If the password is specified as "", then it get hashed. This could cause some head scratching for people that believe that an empty string means no password.