### PR TITLE
Remove decode for text parameter

### DIFF
--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -73,11 +73,6 @@ defmodule Mariaex.Messages do
 
   def __type__(:decode, _type, nil), do: nil
 
-  for {type, list}  <- @types,
-      {_name, id}   <- list   do
-    function_name = :"decode_#{type}"
-    def __type__(:decode, unquote(id), elem), do: unquote(function_name)(elem)
-  end
   for {_type, list} <- @types,
       {name, id}    <- list   do
     def __type__(:id, unquote(name)), do: unquote(id)
@@ -274,40 +269,6 @@ defmodule Mariaex.Messages do
   defp decode_msg(body, :column_count),                                            do: __decode__(:column_count, body)
   defp decode_msg(body, :column_definitions),                                      do: __decode__(:column_definition_41, body)
   defp decode_msg(body, :rows),                                                    do: __decode__(:row, body)
-
-  defp decode_string(data),    do: data
-  defp decode_float(data),     do: String.to_float(data)
-  defp decode_integer(data),   do: String.to_integer(data)
-  defp decode_bit(<<bit>>),    do: bit
-  defp decode_null(_),         do: nil
-  defp decode_boolean("1"),    do: true
-  defp decode_boolean("0"),    do: false
-
-  defp decode_decimal(data) do
-    Decimal.new(data)
-  end
-
-  defp decode_date(data) do
-    String.split(data, "-")
-    |> Enum.map(&String.to_integer/1)
-    |> List.to_tuple
-  end
-
-  defp decode_time(data) do
-    time = String.split(data, [":", "."])
-    |> Enum.map(&String.to_integer/1)
-    |> List.to_tuple
-
-    case time do
-      {hour, min, sec} -> {hour, min, sec, 0}
-      {hour, min, sec, msec} -> {hour, min, sec, msec}
-    end
-  end
-
-  defp decode_timestamp(data)  do
-    [date, time] = String.split(data, " ")
-    {decode_date(date), decode_time(time)}
-  end
 
   def decode_type_row([], [], acc), do: acc |> Enum.reverse |> List.to_tuple
   def decode_type_row([elem | rest_rows], [{_name, type} | rest_defs], acc) do

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -180,5 +180,4 @@ defmodule Mariaex.Protocol do
     statement |> String.split(" ", parts: 2) |> hd |> String.downcase |> String.to_atom
   end
   defp get_command(nil), do: nil
-
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -8,7 +8,7 @@ defmodule QueryTest do
     {:ok, [pid: pid]}
   end
 
-  test "support primitive data types in binary protocol", context do
+  test "support primitive data types using prepared statements", context do
     string  = "Californication"
     text    = "Some random text"
     binary  = <<0,1>>
@@ -35,7 +35,7 @@ defmodule QueryTest do
     assert query("SELECT data from #{table} WHERE id = ?", [1]) == [{binary}]
   end
 
-  test "support numeric data types in binary protocol", context do
+  test "support numeric data types using prepared statements", context do
     integer = 16
     float   = 0.1
     double  = 3.1415
@@ -63,7 +63,7 @@ defmodule QueryTest do
     assert query("SELECT ?", [decimal]) == [{decimal}]
   end
 
-  test "support primitive data types in text protocol", context do
+  test "support primitive data types with prepared statement", context do
     integer          = 1
     negative_integer = -1
     float            = 3.1415


### PR DESCRIPTION
Following 531f41ac6dc46971b9a3db21efdba383c94fe770, these methods can be removed.

Did I forget some method to be removed?

Ref. https://github.com/xerions/mariaex/commit/531f41ac6dc46971b9a3db21efdba383c94fe770#commitcomment-10046834