### PR TITLE
add character set option

### DIFF
--- a/lib/mariaex/connection.ex
+++ b/lib/mariaex/connection.ex
@@ -38,6 +38,7 @@ defmodule Mariaex.Connection do
     * `:formatter` - Function deciding the format for a type;
     * `:parameters` - Keyword list of connection parameters;
     * `:timeout` - Connect timeout in milliseconds (default: 5000);
+    * `:charset` - Database encoding (default: "utf8");
 
   ## Function signatures
 
@@ -62,6 +63,7 @@ defmodule Mariaex.Connection do
         case GenServer.call(pid, {:connect, opts}, timeout) do
           {:ok, _} ->
             Process.link(pid)
+            query(pid, "SET CHARACTER SET " <> (opts[:charset] || "utf8"))
             {:ok, pid}
           err ->
             err

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -312,4 +312,11 @@ defmodule QueryTest do
     assert %Mariaex.Error{message: "query has invalid number of parameters"} = query("SELECT 1", [:badparam])
     assert %Mariaex.Error{message: "query has invalid parameters"} = query("SELECT ?", [:badparam])
   end
+
+  test "non ascii character", context do
+    :ok = query("CREATE TABLE test_charset (id int, text text)", [])
+    :ok = query("INSERT INTO test_charset VALUES (?, ?)", [1, "忍者"])
+
+    assert query("SELECT * FROM test_charset where id = 1", []) == [{1, "忍者"}]
+  end
 end


### PR DESCRIPTION
non ascii characters are broken... :cry:

```elixir
mysql> SELECT * FROM humans LIMIT 1;
+----+---------+
| id | content |
+----+---------+
|  1 | 忍者    |
+----+---------+

iex> Mariaex.Connection.query(p, "SELECT * FROM humans WHERE id = 1")
{:ok,
 %Mariaex.Result{columns: ["id", "content"], command: :select,
  last_insert_id: nil, num_rows: 1, rows: [{1, "??"}]}}
```

This PR add character-set option.

```elixir
iex> {:ok, p} = Mariaex.Connection.start_link(username: "rutan", database: "example", charset: "utf8")
iex> Mariaex.Connection.query(p, "SELECT * FROM humans WHERE id = 1")
 %Mariaex.Result{columns: ["id", "content"], command: :select,
  last_insert_id: nil, num_rows: 1, rows: [{1, "忍者"}]}}
```
