### PR TITLE
Async query

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mariaex.Mixfile do
   def project do
     [app: :mariaex,
      version: "0.4.3",
-     elixir: "~> 1.0",
+     elixir: "~> 1.1",
      deps: deps,
      name: "Mariaex",
      source_url: "https://github.com/liveforeverx/mariaex",

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Mariaex.Mixfile do
 
   defp deps do
     [{:decimal, "~> 1.0"},
-     {:coverex, "~> 1.4.1", only: :test}]
+     {:coverex, "~> 1.4.3", only: :test}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"coverex": {:hex, :coverex, "1.4.1"},
+%{"coverex": {:hex, :coverex, "1.4.3"},
   "decimal": {:hex, :decimal, "1.1.0"},
-  "hackney": {:hex, :hackney, "1.3.1"},
-  "httpoison": {:hex, :httpoison, "0.7.0"},
+  "hackney": {:hex, :hackney, "1.3.2"},
+  "httpoison": {:hex, :httpoison, "0.7.2"},
   "idna": {:hex, :idna, "1.0.2"},
   "poison": {:hex, :poison, "1.4.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -433,4 +433,28 @@ defmodule QueryTest do
     assert _ = query("SHOW FULL PROCESSLIST", [])
   end
 
+  test "async query", context do
+    string  = "Californication"
+    text    = "Some random text"
+    table   = "testing_async_query"
+
+    sql = ~s{CREATE TABLE #{table} } <>
+          ~s{(id serial, title varchar(20), body text(20))}
+
+    :ok = query(sql, [])
+    insert = ~s{INSERT INTO #{table} (title, body) } <>
+             ~s{VALUES (?, ?)}
+    :ok = query(insert, [string, text])
+
+    task1 = async_query("SELECT title from #{table} WHERE id = LAST_INSERT_ID()", [])
+    task2 = async_query("SELECT body from #{table} WHERE id = LAST_INSERT_ID()", [])
+
+    # String
+    {:ok, %{rows: rows}} = Task.await(task1)
+    assert rows == [[string]]
+
+    # Text
+    {:ok, %{rows: rows}} = Task.await(task2)
+    assert rows == [[text]]
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -54,4 +54,10 @@ defmodule Mariaex.TestHelper do
       end
     end
   end
+
+  defmacro async_query(stat, params) do
+    quote do
+      Mariaex.Connection.async_query(var!(context)[:pid], unquote(stat), unquote(params))
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/xerions/mariaex/issues/74

Aside from adding support for async query, this PR introduces a dependency on Elixir 1.1 and uses latest coverex that is compatible to Elixir 1.1.

Async replies can only be supported with Elixir 1.1 because we need GenServer.whereis/1. Again, thanks for the help @fishcakez! This is a lot similar to the Postgrex PR.