### PR TITLE
Bring client decoding back and removing async queries

### DIFF
--- a/lib/mariaex/connection.ex
+++ b/lib/mariaex/connection.ex
@@ -127,40 +127,8 @@ defmodule Mariaex.Connection do
   Runs an (extended) query and returns the result or raises `Mariaex.Error` if
   there was an error. See `query/3`.
   """
-
   def query!(pid, statement, params \\ [], opts \\ []) do
     query(pid, statement, params, opts) |> raiser
-  end
-
-  @doc """
-  Works like `query/2`, `query/3` and `query/4` but is asynchronous. This returns a
-  `%Task{}` and is useful for starting multiple async queries and then waiting on the
-  result later on.
-
-  When server name passed has no process associated, it will raise an error. When the
-  task returns value, it will be the same as the expected return values for the `query`
-  functions.
-
-  ## Examples
-
-      task = %Task{} = Mariaex.Connection.async_query(pid, "SELECT title FROM posts")
-      {:ok, %Mariaex.Result{}} = Task.await(task)
-  """
-  def async_query(pid, statement, params \\ []) do
-    message = {:query, statement, params, []}
-    process = cond do
-        is_pid(pid) ->
-          pid
-        function_exported?(GenServer, :whereis, 1) ->
-          GenServer.whereis(pid) || raise ArgumentError, "No process is associated with #{inspect pid}"
-        true ->
-          raise ArgumentError, "Requires Elixir 1.1 when passing server name as first argument"
-      end
-    monitor = Process.monitor(process)
-    from = {self(), monitor}
-
-    :ok = Connection.cast(pid, {message, from})
-    %Task{ref: monitor}
   end
 
   ### CONNECTION CALLBACKS ###

--- a/lib/mariaex/connection.ex
+++ b/lib/mariaex/connection.ex
@@ -101,6 +101,8 @@ defmodule Mariaex.Connection do
     * `:timeout` - Call timeout (default: `#{@timeout}`)
     * `:param_types` - A list of type names for the parameters
     * `:result_types` - A list of type names for the result rows
+    * `:decode` - If the result set decoding should be done automatically
+       (`:auto`) or manually (`:manual`) via `decode/2`. Defaults to `:auto`.
 
   ## Examples
 
@@ -120,7 +122,15 @@ defmodule Mariaex.Connection do
   def query(pid, statement, params \\ [], opts \\ []) do
     message = {:query, statement, params, opts}
     timeout = opts[:timeout] || @timeout
-    Connection.call(pid, message, timeout)
+    case GenServer.call(pid, message, timeout) do
+      {:ok, %Mariaex.Result{} = res} ->
+        case Keyword.get(opts, :decode, :auto) do
+          :auto   -> {:ok, decode(res)}
+          :manual -> {:ok, res}
+        end
+      error ->
+        error
+    end
   end
 
   @doc """
@@ -129,6 +139,21 @@ defmodule Mariaex.Connection do
   """
   def query!(pid, statement, params \\ [], opts \\ []) do
     query(pid, statement, params, opts) |> raiser
+  end
+
+  @doc """
+  Decodes a result set.
+
+  It is a no-op if the result was already decoded.
+  """
+  def decode(_, mapper \\ fn x -> x end)
+  def decode(%Mariaex.Result{decoder: :done} = result, _), do: result
+  def decode(%Mariaex.Result{rows: rows, decoder: types} = result, mapper) do
+    rows = rows |> Enum.reduce([], &([(Mariaex.Messages.decode_bin_rows(&1, types) |> mapper.()) | &2]))
+    %{result | columns: (for {type, _} <- types, do: type),
+               rows: rows,
+               num_rows: length(rows),
+               decoder: :done}
   end
 
   ### CONNECTION CALLBACKS ###

--- a/lib/mariaex/structs.ex
+++ b/lib/mariaex/structs.ex
@@ -15,9 +15,10 @@ defmodule Mariaex.Result do
     columns:  [String.t] | nil,
     rows:     [tuple] | nil,
     last_insert_id: integer,
-    num_rows: integer}
+    num_rows: integer,
+    decoder: nil | [tuple] | :done}
 
-  defstruct [:command, :columns, :rows, :last_insert_id, :num_rows]
+  defstruct [:command, :columns, :rows, :last_insert_id, :num_rows, :decoder]
 end
 
 defmodule Mariaex.Error do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -432,29 +432,4 @@ defmodule QueryTest do
   test "test rare commands in prepared statements", context do
     assert _ = query("SHOW FULL PROCESSLIST", [])
   end
-
-  test "async query", context do
-    string  = "Californication"
-    text    = "Some random text"
-    table   = "testing_async_query"
-
-    sql = ~s{CREATE TABLE #{table} } <>
-          ~s{(id serial, title varchar(20), body text(20))}
-
-    :ok = query(sql, [])
-    insert = ~s{INSERT INTO #{table} (title, body) } <>
-             ~s{VALUES (?, ?)}
-    :ok = query(insert, [string, text])
-
-    task1 = async_query("SELECT title from #{table} WHERE id = LAST_INSERT_ID()", [])
-    task2 = async_query("SELECT body from #{table} WHERE id = LAST_INSERT_ID()", [])
-
-    # String
-    {:ok, %{rows: rows}} = Task.await(task1)
-    assert rows == [[string]]
-
-    # Text
-    {:ok, %{rows: rows}} = Task.await(task2)
-    assert rows == [[text]]
-  end
 end


### PR DESCRIPTION
Async queries will no longer be needed by Ecto. I have also brought client decoding back but this is a temporary implementation until db_connection is used.