### PR TITLE
Fix protocol for describe command

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -315,7 +315,7 @@ defmodule Mariaex.Protocol do
 
   def send_query(statement, params, s) do
     command = get_command(statement)
-    case command in [:insert, :select, :update, :delete, :show, :call] do
+    case command in [:insert, :select, :update, :delete, :show, :call, :describe] do
       true ->
         case Cache.lookup(s.cache, statement) do
           {id, parameter_types} ->

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -431,6 +431,9 @@ defmodule QueryTest do
 
   test "test rare commands in prepared statements", context do
     assert _ = query("SHOW FULL PROCESSLIST", [])
+
+    :ok = query("CREATE TABLE test_describe (id int)", [])
+    assert query("DESCRIBE test_describe", []) == [["id", "int(11)", "YES", "", nil, ""]]
   end
 
   test "async query", context do


### PR DESCRIPTION
[The query below fails](https://gist.github.com/rodrigues/ec8b0955a4017e291d61):

```elixir
Ecto.Adapters.SQL.query(ETP.Repo, "DESCRIBE groups", [])
```

Not sure this is the right thing to do, but adding `:describe` to [this list](https://github.com/xerions/mariaex/blob/master/lib/mariaex/protocol.ex#L318) of commands seems to fix the problem.

```elixir
Ecto.Adapters.SQL.query(ETP.Repo, "DESCRIBE groups", [])

statement "DESCRIBE groups"
params []
command :describe

[debug] DESCRIBE groups [] OK query=27.3ms queue=65.6ms
{:ok,
 %{columns: ["Field", "Type", "Null", "Key", "Default", "Extra"],
   command: :describe, last_insert_id: nil, num_rows: 26,
   rows: [["id", "int(11)", "NO", "PRI", nil, "auto_increment"],
  # ...
```