### PR TITLE
Add :connection to the list of applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Mariaex.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger, :decimal]]
+    [applications: [:logger, :decimal, :connection]]
   end
 
   defp deps do


### PR DESCRIPTION
It must have been forgotten.
Without this release builds are broken, because releases will only include code from the dependencies in the applications list.