### PR TITLE
Allow connection to mysql server that have an exotic version numbering

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -109,7 +109,7 @@ defmodule Mariaex.Protocol do
     ## That means, without differentiation of MySQL versions, we can't know, if eof after last column definition
     ## is resulting eof after result set (which can be none) or simple information, that now results will be coming.
     ## Due to this, we need to difference server version.
-    protocol57 = String.split(server_version, "-", parts: 2) |> hd |> Version.match?("~> 5.7.5")
+    protocol57 = get_3_digits_version(server_version) |> Version.match?("~> 5.7.5")
     handshake(auth_plugin_data1: salt1, auth_plugin_data2: salt2) = handshake
     authorization(plugin, %{s | protocol57: protocol57, handshake: %{salt: {salt1, salt2}, seqnum: seqnum}})
   end
@@ -401,4 +401,13 @@ defmodule Mariaex.Protocol do
     statement |> :binary.split([" ", "\n"]) |> hd |> String.downcase |> String.to_atom
   end
   defp get_command(nil), do: nil
+
+  defp get_3_digits_version(server_version) do
+    server_version
+    |> String.split("-", parts: 2)
+    |> hd
+    |> String.split(".")
+    |> Enum.slice(0,3)
+    |> Enum.join(".")
+  end
 end


### PR DESCRIPTION
This patch allow mariaex library to connect to mysql servers that have a version containing more than 3 digits. For example : "5.5.18.1-log", without this fix, the library will not be able to start.

```
iex(1)> "5.5.18.1-log" |> Version.match?("~> 5.7.5")
** (Version.InvalidVersionError) 5.5.18.1-log
    (elixir) lib/version.ex:234: Version.to_matchable/1
    (elixir) lib/version.ex:138: Version.match?/2
```

I encountered this problem using this library with an Aliyun RDS MySQL instance. 