### PR TITLE
Add option for the 'columns' list in the result struct to have values…

### DIFF
--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -118,6 +118,9 @@ defmodule Mariaex do
        (default: `fn x -> x end`)
     * `:decode_mapper` - Fun to map each row in the result to a term after
        decoding, (default: `fn x -> x end`);
+    * `:include_table_name` - Boolean specifying whether the `columns` list in
+       the result prepends the table name to the column name with a period.
+       (default `false`)
 
   ## Examples
 

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -253,8 +253,8 @@ defmodule Mariaex.Protocol do
     prepare_may_recv_more(%{state | state: :column_definitions, catch_eof: not state.protocol57, state_data: statedata}, %{query | statement_id: id})
   end
   defp handle_prepare_send(packet(msg: column_definition_41() = msg), %{types: types} = query, state) do
-    column_definition_41(type: type, name: name, flags: flags) = msg
-    query = %{query | types: [{name, type, flags} | types]}
+    column_definition_41(type: type, name: name, flags: flags, table: table) = msg
+    query = %{query | types: [{name, table, type, flags} | types]}
     {query, state} = count_down(query, state)
     prepare_may_recv_more(state, query)
   end
@@ -332,8 +332,8 @@ defmodule Mariaex.Protocol do
     binary_query_recv(%{state | state: :column_definitions, state_data: {count, 0}}, %{query | types: []})
   end
   defp handle_binary_query(packet(msg: column_definition_41() = msg), %{types: types} = query, s) do
-    column_definition_41(type: type, name: name, flags: flags) = msg
-    query = %{query | types: [{name, type, flags} | types]}
+    column_definition_41(type: type, name: name, flags: flags, table: table) = msg
+    query = %{query | types: [{name, table, type, flags} | types]}
     {query, s} = count_down(query, s)
     s = if s.state_data == {0, 0}, do: %{s | state: :bin_rows, catch_eof: not s.protocol57}, else: s
     binary_query_recv(s, query)


### PR DESCRIPTION
… like 'tablename.columnname' rather than only 'columnname'.

This addresses #85 without making any changes to the `%Mariaex.Result{}` struct. When the `include_table_name: true` option is added to a query like
```SQL
SELECT people.*, pets.*
FROM people
JOIN pets on pets.person_id = people.id
```
the `columns` list now contains entries like: `["people.id", "people.name", "pets.id", "pets.name"...]`, which addresses my main concern when I opened #85.
