### PR TITLE
Fix ets lookup in Mariaex.Cache

### DIFF
--- a/lib/mariaex/cache.ex
+++ b/lib/mariaex/cache.ex
@@ -25,7 +25,7 @@ defmodule Mariaex.Cache do
   """
   def delete(cache, name, cleanup) do
     case :ets.lookup(cache, name) do
-      [{_, _, info}] ->
+      [{_, info}] ->
         :ets.delete(cache, name)
         cleanup.(name, info)
       _ ->


### PR DESCRIPTION
Noticed this when reading the code.

Mariaex.Cache.delete matches on a 3-element tuple, but the cache only ever contains 2-element tuples. This could lead to queries never being removed from the table and not cleaned up.

(This doesn't affect real applications, as the delete function never gets called)