### PR TITLE
Rootless tests

### DIFF
--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -3,7 +3,7 @@ defmodule PreparedQueryTest do
   import Mariaex.TestHelper
 
   setup do
-    opts = [database: "mariaex_test", username: "root", backoff_type: :stop]
+    opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
     {:ok, pid} = Mariaex.Connection.start_link(opts)
     {:ok, [pid: pid]}
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -3,7 +3,7 @@ defmodule QueryTest do
   import Mariaex.TestHelper
 
   setup do
-    opts = [database: "mariaex_test", username: "root", backoff_type: :stop]
+    opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
     {:ok, pid} = Mariaex.Connection.start_link(opts)
     {:ok, [pid: pid]}
   end

--- a/test/start_test.exs
+++ b/test/start_test.exs
@@ -4,10 +4,10 @@ defmodule StartTest do
   test "connection_errors" do
     Process.flag :trap_exit, true
     assert {:error, {%Mariaex.Error{mariadb: %{message: "Unknown database 'non_existing'"}}, _}} =
-      Mariaex.Connection.start_link(username: "root", database: "non_existing", sync_connect: true, backoff_type: :stop)
+      Mariaex.Connection.start_link(username: "mariaex_user", password: "mariaex_pass", database: "non_existing", sync_connect: true, backoff_type: :stop)
     assert {:error, {%Mariaex.Error{mariadb: %{message: "Access denied for user " <> _}}, _}} =
       Mariaex.Connection.start_link(username: "non_existing", database: "mariaex_test", sync_connect: true, backoff_type: :stop)
     assert {:error, {%Mariaex.Error{message: "tcp connect: econnrefused"}, _}} =
-      Mariaex.Connection.start_link(username: "root", database: "mariaex_test", port: 60999, sync_connect: true, backoff_type: :stop)
+      Mariaex.Connection.start_link(username: "mariaex_user", password: "mariaex_pass", database: "mariaex_test", port: 60999, sync_connect: true, backoff_type: :stop)
   end
 end


### PR DESCRIPTION
Allow mysql root password to be supplied as an environment variable and always use mariaex_user instead of root user in tests.