### PR TITLE
Fix utf8 client to latin1 encoded table writes

### DIFF
--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -100,8 +100,7 @@ defimpl DBConnection.Query, for: Mariaex.Query do
   defp encode_param(nil),
     do: {1, :field_type_null, ""}
   defp encode_param(bin) when is_binary(bin) do
-    field_type = if String.valid?(bin), do: :field_type_var_string, else: :field_type_blob
-    {0, field_type, << to_length_encoded_integer(byte_size(bin)) :: binary, bin :: binary >>}
+    {0, :field_type_var_string, << to_length_encoded_integer(byte_size(bin)) :: binary, bin :: binary >>}
   end
   defp encode_param(int) when is_integer(int),
     do: {0, :field_type_longlong, << int :: 64-little >>}

--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -99,8 +99,10 @@ defimpl DBConnection.Query, for: Mariaex.Query do
 
   defp encode_param(nil),
     do: {1, :field_type_null, ""}
-  defp encode_param(bin) when is_binary(bin),
-    do: {0, :field_type_blob, << to_length_encoded_integer(byte_size(bin)) :: binary, bin :: binary >>}
+  defp encode_param(bin) when is_binary(bin) do
+    field_type = if String.valid?(bin), do: :field_type_var_string, else: :field_type_blob
+    {0, field_type, << to_length_encoded_integer(byte_size(bin)) :: binary, bin :: binary >>}
+  end
   defp encode_param(int) when is_integer(int),
     do: {0, :field_type_longlong, << int :: 64-little >>}
   defp encode_param(float) when is_float(float),

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -3,7 +3,7 @@ defmodule PreparedQueryTest do
   import Mariaex.TestHelper
 
   setup do
-    opts = [database: "mariaex_test", username: "root", backoff_type: :stop]
+    opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
     {:ok, pid} = Mariaex.Connection.start_link(opts)
     {:ok, [pid: pid]}
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -508,6 +508,13 @@ defmodule QueryTest do
     assert query("SELECT * FROM test_charset where id = 1", []) == [[1, "忍者"]]
   end
 
+  test "non ascii character to latin1 table", context do
+    :ok = query("CREATE TABLE test_charset_latin1 (id int, text text) DEFAULT CHARSET=latin1", [])
+    :ok = query("INSERT INTO test_charset_latin1 VALUES (?, ?)", [1, "ÖÄÜß"])
+
+    assert query("SELECT * FROM test_charset_latin1 where id = 1", []) == [[1, "ÖÄÜß"]]
+  end
+
   test "test nullbit", context do
     :ok = query("CREATE TABLE test_nullbit (id int, t1 text, t2 text, t3 text, t4 text, t5 text not NULL, t6 text, t7 text not NULL)", [])
     :ok = query("INSERT INTO test_nullbit VALUES (?, ?, ?, ?, ?, ?, ?, ?)", [nil, "t1", nil, "t3", nil, "t5", nil, "t7"])

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -68,7 +68,7 @@ defmodule QueryTest do
     assert query("SELECT data from #{table} WHERE id = LAST_INSERT_ID()", []) == [[binary]]
   end
 
-  test "booleen and tiny int tests", context do
+  test "boolean and tiny int tests", context do
     table = "boolean_test"
     :ok = query("CREATE TABLE #{table} (id serial, active boolean, tiny tinyint)", [])
 
@@ -79,7 +79,7 @@ defmodule QueryTest do
     assert query("SELECT active, tiny from #{table} WHERE id = ?", [2]) == [[1, -128]]
   end
 
-  test "booleen and unsigned tiny int tests", context do
+  test "boolean and unsigned tiny int tests", context do
     table = "boolean_test_unsigned"
     :ok = query("CREATE TABLE #{table} (id serial, active boolean, tiny tinyint unsigned)", [])
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -3,7 +3,7 @@ defmodule QueryTest do
   import Mariaex.TestHelper
 
   setup do
-    opts = [database: "mariaex_test", username: "root", backoff_type: :stop]
+    opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
     {:ok, pid} = Mariaex.Connection.start_link(opts)
     {:ok, [pid: pid]}
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -74,9 +74,11 @@ defmodule QueryTest do
 
     :ok = query(~s{INSERT INTO #{table} (id, active, tiny) VALUES (?, ?, ?)}, [1, 0, 127])
     :ok = query(~s{INSERT INTO #{table} (id, active, tiny) VALUES (?, ?, ?)}, [2, true, -128])
+    :ok = query(~s{INSERT INTO #{table} (id, active, tiny) VALUES (?, ?, ?)}, [3, false, -128])
 
     assert query("SELECT active, tiny from #{table} WHERE id = ?", [1]) == [[0, 127]]
     assert query("SELECT active, tiny from #{table} WHERE id = ?", [2]) == [[1, -128]]
+    assert query("SELECT active, tiny from #{table} WHERE id = ?", [3]) == [[0, -128]]
   end
 
   test "boolean and unsigned tiny int tests", context do

--- a/test/start_test.exs
+++ b/test/start_test.exs
@@ -4,10 +4,10 @@ defmodule StartTest do
   test "connection_errors" do
     Process.flag :trap_exit, true
     assert {:error, {%Mariaex.Error{mariadb: %{message: "Unknown database 'non_existing'"}}, _}} =
-      Mariaex.Connection.start_link(username: "root", database: "non_existing", sync_connect: true, backoff_type: :stop)
+      Mariaex.Connection.start_link(username: "mariaex_user", password: "mariaex_pass", database: "non_existing", sync_connect: true, backoff_type: :stop)
     assert {:error, {%Mariaex.Error{mariadb: %{message: "Access denied for user " <> _}}, _}} =
       Mariaex.Connection.start_link(username: "non_existing", database: "mariaex_test", sync_connect: true, backoff_type: :stop)
     assert {:error, {%Mariaex.Error{message: "tcp connect: econnrefused"}, _}} =
-      Mariaex.Connection.start_link(username: "root", database: "mariaex_test", port: 60999, sync_connect: true, backoff_type: :stop)
+      Mariaex.Connection.start_link(username: "mariaex_user", password: "mariaex_pass", database: "mariaex_test", port: 60999, sync_connect: true, backoff_type: :stop)
   end
 end


### PR DESCRIPTION
Fixes #110 

Fix encoding of utf8 encoded params on insert and update to a latin1 encoded table.

To make an insert of utf8 encoded char params to a latin1 encoded table
work, the field type has to be of :field_type_var_string.