### PR TITLE
Normalize port

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -74,12 +74,15 @@ defmodule Mariaex.Protocol do
     |> Keyword.put_new(:username, System.get_env("MDBUSER") || System.get_env("USER"))
     |> Keyword.put_new(:password, System.get_env("MDBPASSWORD"))
     |> Keyword.put_new(:hostname, System.get_env("MDBHOST") || "localhost")
-    |> Keyword.put_new(:port, 3306)
     |> Keyword.put_new(:timeout, @timeout)
     |> Keyword.put_new(:cache_size, @cache_size)
     |> Keyword.put_new(:sock_type, :tcp)
     |> Keyword.put_new(:socket_options, [])
+    |> Keyword.update(:port, 3306, &normalize_port/1)
   end
+
+  defp normalize_port(port) when is_binary(port), do: String.to_integer(port)
+  defp normalize_port(port) when is_integer(port), do: port
 
   defp handshake_recv(state, request) do
     case msg_recv(state) do


### PR DESCRIPTION
Since ports are commonly given as part of environment variables,
let's make sure to normalize string values into integers.