### PR TITLE
add crypto to the applications list so release tools know to include …

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Mariaex.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger, :decimal, :db_connection]]
+    [applications: [:logger, :crypto, :decimal, :db_connection]]
   end
 
   defp deps do


### PR DESCRIPTION
…it on startup.

The `:crypto` module is used in `Protocol.mysql_native_password/2`, but the `:crypto` application isn't started by default when generating a release with `exrm` (though I presume any release-generation tool will have this issue).

The workaround is to include `:crypto` in the `applications` list of the project using `mariaex`, but I think adding it to `mariaex`'s `applications` list is the more correct solution.

An example of the error seen when trying to run a release which uses mariaex:

```bash
$ rel/test_app/bin/test_app console
Exec: /Users/jordan/development/test_app/rel/test_app/erts-7.2.1/bin/erlexec -boot /Users/jordan/development/test_app/rel/test_app/releases/0.0.1/test_app -config /Users/jordan/development/test_app/rel/test_app/running-config/sys.config -boot_var ERTS_LIB_DIR /Users/jordan/development/test_app/rel/test_app/erts-7.2.1/../lib -env ERL_LIBS /Users/jordan/development/test_app/rel/test_app/lib -pa /Users/jordan/development/test_app/rel/test_app/lib/test_app-0.0.1/consolidated -args_file /Users/jordan/development/test_app/rel/test_app/running-config/vm.args -mode embedded -user Elixir.IEx.CLI -extra --no-halt +iex -- console
Root: /Users/jordan/development/test_app/rel/test_app
/Users/jordan/development/test_app/rel/test_app
Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Interactive Elixir (1.2.0) - press Ctrl+C to exit (type h() ENTER for help)
iex(test_app@Jordans-MacBook-Pro)1>
09:53:42.948 [error] GenServer #PID<0.722.0> terminating
** (UndefinedFunctionError) undefined function :crypto.hash/2 (module :crypto is not available)
    :crypto.hash(:sha, "db_password")
    (mariaex) lib/mariaex/protocol.ex:475: Mariaex.Protocol.mysql_native_password/2
    (mariaex) lib/mariaex/protocol.ex:113: Mariaex.Protocol.handle_handshake/3
    (db_connection) lib/db_connection/connection.ex:114: DBConnection.Connection.connect/2
    (connection) lib/connection.ex:623: Connection.enter_connect/5
    (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: nil
State: nil

=CRASH REPORT==== 2-Jun-2016::09:53:42 ===
  crasher:
    initial call: Elixir.DBConnection.Connection:init/1
    pid: <0.722.0>
    registered_name: []
    exception exit: {undef,
                        [{crypto,hash,[sha,<<"db_password">>],[]},
                         {'Elixir.Mariaex.Protocol',mysql_native_password,2,
                             [{file,"lib/mariaex/protocol.ex"},{line,475}]},
                         {'Elixir.Mariaex.Protocol',handle_handshake,3,
                             [{file,"lib/mariaex/protocol.ex"},{line,113}]},
                         {'Elixir.DBConnection.Connection',connect,2,
                             [{file,"lib/db_connection/connection.ex"},
                              {line,114}]},
                         {'Elixir.Connection',enter_connect,5,
                             [{file,"lib/connection.ex"},{line,623}]},
                         {proc_lib,init_p_do_apply,3,
                             [{file,"proc_lib.erl"},{line,240}]}]}
      in function  'Elixir.Connection':enter_stop/5 (lib/connection.ex, line 687)
    ancestors: [<0.710.0>,'Elixir.TestApp.Repo.Pool',
                  'Elixir.TestApp.Repo',
                  'Elixir.TestApp.Supervisor',<0.706.0>]
    messages: []
    links: [<0.709.0>,<0.710.0>,#Port<0.2620>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 1598
    stack_size: 27
    reductions: 1211
  neighbours:
```