### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Mariaex [![Build Status](https://travis-ci.org/xerions/mariaex.svg)](https://travis-ci.org/xerions/mariaex) [![Coverage Status](https://coveralls.io/repos/xerions/mariaex/badge.svg?branch=master&service=github)](https://coveralls.io/github/xerions/mariaex?branch=master)
+Mariaex [![Build Status](https://travis-ci.org/xerions/mariaex.svg)](https://travis-ci.org/xerions/mariaex) [![Coverage Status](https://coveralls.io/repos/xerions/mariaex/badge.svg?branch=master&service=github)](https://coveralls.io/github/xerions/mariaex?branch=master) [![Deps Status](https://beta.hexfaktor.org/badge/all/github/xerions/mariaex.svg)](https://beta.hexfaktor.org/github/xerions/mariaex)
 =======
 
 ## Usage


### PR DESCRIPTION
Hi there,

first off: Loving mariaex. Am using it for [ElixirStatus](http://elixirstatus.com) and can not make a single complaint, works like clockwork :+1: 

I wanted to take a moment to pitch my latest project for the Elixir community:

  [![Deps Status](https://beta.hexfaktor.org/badge/all/github/xerions/mariaex.svg)](https://beta.hexfaktor.org/github/xerions/mariaex)

This badge shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!