### PR TITLE
Add tls supoprt

### DIFF
--- a/lib/mariaex/connection/ssl.ex
+++ b/lib/mariaex/connection/ssl.ex
@@ -1,0 +1,32 @@
+defmodule Mariaex.Connection.Ssl do
+
+  def recv(sock, bytes, timeout), do: :ssl.recv(sock, bytes, timeout)
+
+  def recv_active(sock, timeout, buffer \\ :active_once) do
+    receive do
+      {:ssl, ^sock, buffer} ->
+        {:ok, buffer}
+      {:ssl_closed, ^sock} ->
+        {:disconnect, {tag, "async_recv", :closed, buffer}}
+      {:ssl_error, ^sock, reason} ->
+        {:disconnect, {tag, "async_recv", reason, buffer}}
+    after
+      timeout ->
+        {:ok, <<>>}
+    end
+  end
+
+  def tag(), do: :ssl
+
+  def fake_message(sock, buffer), do: {:ssl, sock, buffer}
+
+  def receive(_sock, {:ssl, _, blob}), do: blob
+
+  def setopts({:sslsocket, {:gen_tcp, sock, :tls_connection, _},_pid}, opts) do
+    :inet.setopts(sock, opts)
+  end
+
+  def send(sock, data), do: :ssl.send(sock, data)
+
+  def close(sock), do: :ssl.close(sock)
+end

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -105,6 +105,13 @@ defmodule Mariaex.Messages do
     database :string
   end
 
+  defcoder :ssl_connection_request do
+    capability_flags 4
+    max_size 4
+    character_set 1
+    _ 23
+  end
+
   defcoder :old_password do
     password :string
   end

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -181,7 +181,6 @@ defmodule Mariaex.Protocol do
 
   defp upgrade_to_ssl(%{sock: {_sock_mod, sock}} = s, %{opts: opts}) do
     ssl_opts = opts[:ssl_opts]
-    |> Keyword.put_new(:ciphers, :ssl.cipher_suites(:all))
     case :ssl.connect(sock, ssl_opts, opts[:timeout]) do
       {:ok, ssl_sock} ->
         # switch to the ssl connection module

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -181,8 +181,7 @@ defmodule Mariaex.Protocol do
 
   defp upgrade_to_ssl(%{sock: {_sock_mod, sock}} = s, %{opts: opts}) do
     ssl_opts = opts[:ssl_opts]
-    |> Keyword.put_new(:versions, [:tlsv1])    # TODO: support for other TLS versions?
-    |> Keyword.put_new(:ciphers, :ssl.cipher_suites(:openssl))
+    |> Keyword.put_new(:ciphers, :ssl.cipher_suites(:all))
     case :ssl.connect(sock, ssl_opts, opts[:timeout]) do
       {:ok, ssl_sock} ->
         # switch to the ssl connection module

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -27,6 +27,7 @@ defmodule Mariaex.Protocol do
   @client_connect_with_db   0x00000008
   @client_local_files       0x00000080
   @client_protocol_41       0x00000200
+  @client_ssl               0x00000800
   @client_transactions      0x00002000
   @client_secure_connection 0x00008000
   @client_multi_statements  0x00010000
@@ -38,13 +39,26 @@ defmodule Mariaex.Protocol do
                 @client_secure_connection ||| @client_multi_statements  ||| @client_multi_results |||
                 @client_deprecate_eof
 
-  defstruct [sock: nil, connection_ref: nil, state: nil, state_data: nil, protocol57: false,
-             rows: [], connection_id: nil, opts: [], catch_eof: false, buffer: "", timeout: 0,
-             lru_cache: nil, cache: nil, seqnum: 0]
+  defstruct sock: nil,
+            connection_ref: nil,
+            state: nil,
+            state_data: nil,
+            protocol57: false,
+            rows: [],
+            connection_id: nil,
+            opts: [],
+            catch_eof: false,
+            buffer: "",
+            timeout: 0,
+            lru_cache: nil,
+            cache: nil,
+            seqnum: 0,
+            ssl_conn_state: :undefined  #  :undefined | :not_used | :ssl_handshake | :connected
 
   @doc """
   DBConnection callback
   """
+
   def connect(opts) do
     opts         = default_opts(opts)
     sock_type    = opts[:sock_type] |> Atom.to_string |> String.capitalize()
@@ -56,6 +70,7 @@ defmodule Mariaex.Protocol do
     case apply(sock_mod, :connect, connect_opts) do
       {:ok, sock} ->
         s = %__MODULE__{state: :handshake,
+                        ssl_conn_state: set_initial_ssl_conn_state(opts),
                         connection_id: self,
                         connection_ref: make_ref,
                         sock: {sock_mod, sock},
@@ -69,6 +84,7 @@ defmodule Mariaex.Protocol do
     end
   end
 
+
   defp default_opts(opts) do
     opts
     |> Keyword.put_new(:username, System.get_env("MDBUSER") || System.get_env("USER"))
@@ -79,7 +95,19 @@ defmodule Mariaex.Protocol do
     |> Keyword.put_new(:sock_type, :tcp)
     |> Keyword.put_new(:socket_options, [])
     |> Keyword.update(:port, 3306, &normalize_port/1)
+    end
+
+  defp set_initial_ssl_conn_state(opts) do
+    if opts[:ssl] && has_ssl_opts?(opts[:ssl_opts]) do
+      :ssl_handshake
+    else
+      :not_used
+    end
   end
+
+  defp has_ssl_opts?(nil), do: false
+  defp has_ssl_opts?([]), do: false
+  defp has_ssl_opts?(ssl_opts) when is_list(ssl_opts), do: true
 
   defp normalize_port(port) when is_binary(port), do: String.to_integer(port)
   defp normalize_port(port) when is_integer(port), do: port
@@ -100,10 +128,19 @@ defmodule Mariaex.Protocol do
   end
   defp connected(other), do: other
 
+  # request to communicate over an SSL connection
+  defp handle_handshake(packet(seqnum: seqnum) = packet, opts, %{ssl_conn_state: :ssl_handshake} = s) do
+    # Create and send an SSL request packet per the spec: https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
+    msg = ssl_connection_request(capability_flags: ssl_capabilities(opts), max_size: @maxpacketbytes, character_set: 8)
+    msg_send(msg, s, new_seqnum = seqnum + 1)
+    {:ok, new_state} = upgrade_to_ssl(s, opts)
+    # move along to the actual handshake; now over SSL/TLS
+    handle_handshake(packet(packet, seqnum: new_seqnum), opts, new_state)
+  end
   defp handle_handshake(packet(seqnum: seqnum, msg: handshake(server_version: server_version, plugin: plugin) = handshake) = _packet,  %{opts: opts}, s) do
     ## It is a little hack here. Because MySQL before 5.7.5 (at least, I need to asume this or test it with versions 5.7.X, where X < 5),
     ## but all points in documentation to changes shows, that changes done in 5.7.5, but haven't tested it further.
-    ## In a phase of geting binary protocol resultset ( https://dev.mysql.com/doc/internals/en/binary-protocol-resultset.html )
+    ## In a phase of getting binary protocol resultset ( https://dev.mysql.com/doc/internals/en/binary-protocol-resultset.html )
     ## we get in versions before 5.7.X eof packet after last ColumnDefinition and one for the ending of query.
     ## That means, without differentiation of MySQL versions, we can't know, if eof after last column definition
     ## is resulting eof after result set (which can be none) or simple information, that now results will be coming.
@@ -122,7 +159,7 @@ defmodule Mariaex.Protocol do
     msg_send(msg, s, seqnum + 1)
     handshake_recv(%{s | state: :handshake_send, protocol57: protocol57}, nil)
   end
-  defp handle_handshake(packet(msg: ok_resp(affected_rows: _affected_rows, last_insert_id: _last_insert_id)), nil, state) do
+  defp handle_handshake(packet(msg: ok_resp(affected_rows: _affected_rows, last_insert_id: _last_insert_id) = _packet), nil, state) do
     statement = "SET CHARACTER SET " <> (state.opts[:charset] || "utf8")
     query = %Query{type: :text, statement: statement}
     case send_text_query(state, statement) |> text_query_recv(query) do
@@ -137,10 +174,32 @@ defmodule Mariaex.Protocol do
     {:error, error}
   end
 
+  defp upgrade_to_ssl(%{sock: {_sock_mod, sock}} = s, %{opts: opts}) do
+    ssl_opts = opts[:ssl_opts]
+    |> Keyword.put_new(:versions, [:tlsv1])    # TODO: support for other TLS versions?
+    |> Keyword.put_new(:ciphers, :ssl.cipher_suites(:openssl))
+    case :ssl.connect(sock, ssl_opts, opts[:timeout]) do
+      {:ok, ssl_sock} ->
+        # switch to the ssl connection module
+        # set the socket
+        # move ssl_conn_state to :connected
+        {:ok, %{s | sock: {Mariaex.Connection.Ssl, ssl_sock}, ssl_conn_state: :connected}}
+      {:error, reason} ->
+        {:error, %Mariaex.Error{message: "failed to upgraded socket: #{reason}"}}
+    end
+  end
+
   defp capabilities(opts) do
     case opts[:skip_database] do
       true -> {"", @capabilities}
       _    -> {opts[:database], @capabilities ||| @client_connect_with_db}
+    end
+  end
+
+  defp ssl_capabilities(%{opts: opts}) do
+    case opts[:skip_database] do
+      true -> @capabilities ||| @client_ssl
+      _    -> @capabilities ||| @client_connect_with_db ||| @client_ssl
     end
   end
 
@@ -523,7 +582,6 @@ defmodule Mariaex.Protocol do
   end
 
   defp msg_send(msg, %{sock: {sock_mod, sock}}, seqnum), do: msg_send(msg, {sock_mod, sock}, seqnum)
-
   defp msg_send(msgs, {sock_mod, sock}, seqnum) when is_list(msgs) do
     binaries = Enum.reduce(msgs, [], &[&2 | encode(&1, seqnum)])
     sock_mod.send(sock, binaries)

--- a/test/start_test.exs
+++ b/test/start_test.exs
@@ -21,9 +21,9 @@ defmodule StartTest do
                      database: "mariaex_test",
                      sync_connect: true,
                      ssl: true,
-                 ssl_opts: [cacertfile: "",
-                            verify: :verify_peer,
-                            versions: [:"tlsv1.2"]],
+                     ssl_opts: [cacertfile: "",
+                                verify: :verify_peer,
+                                versions: [:"tlsv1.2"]],
                      backoff_type: :stop]
 
     Process.flag :trap_exit, true

--- a/test/start_test.exs
+++ b/test/start_test.exs
@@ -10,4 +10,24 @@ defmodule StartTest do
     assert {:error, {%Mariaex.Error{message: "tcp connect: econnrefused"}, _}} =
       Mariaex.Connection.start_link(username: "mariaex_user", password: "mariaex_pass", database: "mariaex_test", port: 60999, sync_connect: true, backoff_type: :stop)
   end
+
+  ## Tests tagged with :ssl_tests are excluded from running by default (see test_helper.exs)
+  ## as they require that your Mariaex/MySQL server instance be configured for SSL logins:
+  ## https://dev.mysql.com/doc/refman/5.7/en/creating-ssl-files-using-openssl.html
+  @tag :ssl_tests
+  test "ssl_connection_errors" do
+    test_opts = [username: "mariaex_user",
+                     password: "mariaex_pass",
+                     database: "mariaex_test",
+                     sync_connect: true,
+                     ssl: true,
+                     ssl_opts: [cacertfile: "", verify: :verify_peer],
+                     backoff_type: :stop]
+
+    Process.flag :trap_exit, true
+    assert {:error, {%Mariaex.Error{message: "failed to upgraded socket: {:tls_alert, 'unknown ca'}"}, _}} =
+      Mariaex.Connection.start_link(test_opts)
+    assert {:error, {%Mariaex.Error{message: "failed to upgraded socket: {:options, {:cacertfile, []}}"}, _}}  =
+      Mariaex.Connection.start_link(Keyword.put(test_opts, :ssl_opts, Keyword.drop(test_opts[:ssl_opts], [:cacertfile])))
+  end
 end

--- a/test/start_test.exs
+++ b/test/start_test.exs
@@ -21,7 +21,9 @@ defmodule StartTest do
                      database: "mariaex_test",
                      sync_connect: true,
                      ssl: true,
-                     ssl_opts: [cacertfile: "", verify: :verify_peer],
+                 ssl_opts: [cacertfile: "",
+                            verify: :verify_peer,
+                            versions: [:"tlsv1.2"]],
                      backoff_type: :stop]
 
     Process.flag :trap_exit, true

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
+ExUnit.configure exclude: [:ssl_tests]
 ExUnit.start()
 
 run_cmd = fn cmd ->


### PR DESCRIPTION
Adds SSL/TLS connection support using the normal elixir/erlang SSL setup options.    Requires `:ssl` set to `true`, `ssl_opts` set using valid SSL setup options per the [Erlang SSL documentation](http://erlang.org/doc/man/ssl.html), and of course [Mariax/MySQL SSL setup ](https://dev.mysql.com/doc/refman/5.7/en/creating-ssl-files-using-openssl.html) on the pertinent server.

*Example Phoenix configuration*

```elixir
config :my_app, MyApp.Repo,
  adapter: Ecto.Adapters.MySQL,
  username: "ssluser",
  password: "ssltest!",
  database: "my_app_db",
  hostname: "localhost",
  ssl: true,
  ssl_opts: [cacertfile: "/path/to/ca-cert-file.pem",
             verify: :verify_peer,
             versions: [:"tlsv1.2", :"tlsv1.1", :tlsv1]
             ciphers:  :ssl.cipher_suites(:all)],
  ```
