### PR TITLE
Fixes SQL command extraction in the presence of leading whitespace.

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -675,7 +675,7 @@ defmodule Mariaex.Protocol do
   Get command from statement
   """
   def get_command(statement) when is_binary(statement) do
-    statement |> :binary.split([" ", "\n"]) |> hd |> String.downcase |> String.to_atom
+    Regex.run(~r"\w+", statement) |> hd |> String.downcase |> String.to_atom
   end
   def get_command(nil), do: nil
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -21,6 +21,12 @@ defmodule QueryTest do
     assert query("SELECT * FROM test_pass", []) == [[27, "foobar"]]
   end
 
+  test "non-row query with leading whitespace", context do
+    :ok = query("""
+      CREATE TABLE test_leading_whitespace (id int, text text)
+    """, [])
+  end
+
   test "connection without database" do
     opts = [username: "mariaex_user", password: "mariaex_pass", skip_database: true]
     {:ok, pid} = Mariaex.Connection.start_link(opts)


### PR DESCRIPTION
I found this while trying to create an Ecto migration using explicit SQL via an `execute` directive with a heredoc.

I couldn't get the coverage build running as per `.travis.yml`, but did get the tests to run and pass.

Please let me know if there's anything else I can do for this. Thanks!
