### PR TITLE
Fix a bunch of Elixir 1.4 warnings

### DIFF
--- a/lib/mariaex/connection/ssl.ex
+++ b/lib/mariaex/connection/ssl.ex
@@ -7,9 +7,9 @@ defmodule Mariaex.Connection.Ssl do
       {:ssl, ^sock, buffer} ->
         {:ok, buffer}
       {:ssl_closed, ^sock} ->
-        {:disconnect, {tag, "async_recv", :closed, buffer}}
+        {:disconnect, {tag(), "async_recv", :closed, buffer}}
       {:ssl_error, ^sock, reason} ->
-        {:disconnect, {tag, "async_recv", reason, buffer}}
+        {:disconnect, {tag(), "async_recv", reason, buffer}}
     after
       timeout ->
         {:ok, <<>>}

--- a/lib/mariaex/connection/tcp.ex
+++ b/lib/mariaex/connection/tcp.ex
@@ -24,9 +24,9 @@ defmodule Mariaex.Connection.Tcp do
       {:tcp, ^sock, buffer} ->
         {:ok, buffer}
       {:tcp_closed, ^sock} ->
-        {:disconnect, {tag, "async_recv", :closed, buffer}}
+        {:disconnect, {tag(), "async_recv", :closed, buffer}}
       {:tcp_error, ^sock, reason} ->
-        {:disconnect, {tag, "async_recv", reason, buffer}}
+        {:disconnect, {tag(), "async_recv", reason, buffer}}
     after
       timeout ->
         {:ok, <<>>}

--- a/lib/mariaex/lru_cache.ex
+++ b/lib/mariaex/lru_cache.ex
@@ -27,11 +27,11 @@ defmodule Mariaex.LruCache do
 
   def insert({size, cache}, statement, data, cleanup) do
     if :ets.info(cache, :size) > size, do: remove_oldest(cache, cleanup)
-    :ets.insert(cache, {statement, timestamp, data})
+    :ets.insert(cache, {statement, timestamp(), data})
   end
 
   def update({_, cache}, statement, data) do
-    :ets.insert(cache, {statement, timestamp, data})
+    :ets.insert(cache, {statement, timestamp(), data})
   end
 
   defp remove_oldest(cache, cleanup) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,12 +5,12 @@ defmodule Mariaex.Mixfile do
     [app: :mariaex,
      version: "0.7.8",
      elixir: "~> 1.0",
-     deps: deps,
+     deps: deps(),
      name: "Mariaex",
      source_url: "https://github.com/liveforeverx/mariaex",
      test_coverage: [tool: Coverex.Task, coveralls: true],
-     description: description,
-     package: package]
+     description: description(),
+     package: package()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
They're about parens in local 0-arity functions.