### PR TITLE
Handle text protocol COM_QUERY response

### DIFF
--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -177,6 +177,10 @@ defmodule Mariaex.Messages do
     row :string_eof
   end
 
+  defcoder :text_row do
+    row :string_eof
+  end
+
   defcoder :column_definition_41 do
     catalog   :length_encoded_string
     schema    :length_encoded_string
@@ -219,6 +223,7 @@ defmodule Mariaex.Messages do
   defp decode_msg(<< 0 :: 8, _ :: binary >> = body, _),                            do: __decode__(:ok_resp, body)
   defp decode_msg(<< 254 >> = _body, _),                                           do: :mysql_old_password
   defp decode_msg(<< 254 :: 8, _ :: binary >> = body, _) when byte_size(body) < 9, do: __decode__(:eof_resp, body)
+  defp decode_msg(<< _ :: binary >> = body, :text_rows),                    do: __decode__(:text_row, body)
   defp decode_msg(body, :column_count),                                            do: __decode__(:column_count, body)
   defp decode_msg(body, :column_definitions),                                      do: __decode__(:column_definition_41, body)
 end

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -391,8 +391,31 @@ defmodule Mariaex.Protocol do
   end
 
   def_handle :text_query_recv, :handle_text_query
-  defp handle_text_query(packet(msg: ok_resp()) = packet, query, s), do: handle_ok_packet(packet, query, s)
-  defp handle_text_query(packet, query, s), do: handle_error(packet, query, s)
+  defp handle_text_query(packet(msg: ok_resp()) = packet, query, state) do
+    handle_ok_packet(packet, query, state)
+  end
+  defp handle_text_query(packet(msg: column_count(column_count: count)), query, state) do
+    text_query_recv(%{state | state: :column_definitions, state_data: {count, 0}}, %{query | types: []})
+  end
+  defp handle_text_query(packet(msg: column_definition_41() = msg), query, s) do
+    query = add_column(query, msg)
+    {query, s} = count_down(query, s)
+    s = if s.state_data == {0, 0}, do: %{s | catch_eof: true}, else: s
+    text_query_recv(s, query)
+  end
+  defp handle_text_query(packet(msg: eof_resp()), %{statement: statement} = query, s = %{catch_eof: catch_eof}) do
+    if catch_eof do
+      text_query_recv(%{s | state: :text_rows}, query)
+    else
+      {:ok, {%Mariaex.Result{rows: s.rows}, query.types}, clean_state(s)}
+    end
+  end
+  defp handle_text_query(packet(msg: text_row(row: row)) = packet, query, s = %{rows: acc}) do
+    text_query_recv(%{s | rows: [row | acc], catch_eof: false}, query)
+  end
+  defp handle_text_query(packet, query, state) do
+    handle_error(packet, query, state)
+  end
 
   defp handle_error(packet(msg: error_resp(error_code: code, error_message: message)), query, state) do
     abort_statement(state, query, code, message)

--- a/lib/mariaex/protocol_helper.ex
+++ b/lib/mariaex/protocol_helper.ex
@@ -1,4 +1,9 @@
 defmodule Mariaex.ProtocolHelper do
+  @doc"""
+  Define a packet handler, `recv_func/2`.
+  If a packet is received successfully, it will pass `(packet, request, state)` from MariaDB to `handle_func/3`.
+  Otherwise, it will disconnect from the database.
+  """
   defmacro def_handle(recv_func, handle_func) do
     quote do
       defp unquote(recv_func)(state, request) do

--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -147,8 +147,7 @@ defimpl DBConnection.Query, for: Mariaex.Query do
   @unsigned_flag 0x20
 
   def decode(_, %{rows: nil} = res, _), do: res
-  def decode(_, {%{rows: []} = res, _}, _), do: res
-  def decode(%Mariaex.Query{statement: statement, type: query_type} = query, {res, types}, opts) do
+  def decode(%Mariaex.Query{statement: statement, type: query_type}, {res, types}, opts) do
     command = Mariaex.Protocol.get_command(statement)
     if command in @commands_without_rows do
       %Mariaex.Result{res | command: command, rows: nil}

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -13,10 +13,10 @@ defmodule PreparedQueryTest do
     assert with_prepare!("test", "SELECT * FROM prepared_test", []) == []
   end
 
-  # test "unprepared query should work", context do
-  #   :ok = query("CREATE TABLE unprepared_test (id int, text text)", [])
-  #   conn = context[:pid]
-  #   query = %Mariaex.Query{type: :binary, name: "unprepared_test", statement: "SELECT * FROM unprepared_test"}
-  #   assert %{rows: []} = Mariaex.execute!(conn, query, [])
-  # end
+  test "unprepared query should work", context do
+    :ok = query("CREATE TABLE unprepared_test (id int, text text)", [])
+    conn = context[:pid]
+    query = %Mariaex.Query{type: :binary, name: "unprepared_test", statement: "SELECT * FROM unprepared_test"}
+    assert %{rows: []} = Mariaex.execute!(conn, query, [])
+  end
 end

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -13,10 +13,10 @@ defmodule PreparedQueryTest do
     assert with_prepare!("test", "SELECT * FROM prepared_test", []) == []
   end
 
-  test "unprepared query should work", context do
-    :ok = query("CREATE TABLE unprepared_test (id int, text text)", [])
-    conn = context[:pid]
-    query = %Mariaex.Query{type: :binary, name: "unprepared_test", statement: "SELECT * FROM unprepared_test"}
-    assert %{rows: []} = Mariaex.execute!(conn, query, [])
-  end
+  # test "unprepared query should work", context do
+  #   :ok = query("CREATE TABLE unprepared_test (id int, text text)", [])
+  #   conn = context[:pid]
+  #   query = %Mariaex.Query{type: :binary, name: "unprepared_test", statement: "SELECT * FROM unprepared_test"}
+  #   assert %{rows: []} = Mariaex.execute!(conn, query, [])
+  # end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,7 +36,7 @@ cmds = [
 
 Enum.each(cmds, fn cmd ->
   {status, output} = run_cmd.(cmd)
-  IO.puts "--> #{output}"
+  IO.puts ""
 
   if status != 0 do
     IO.puts """
@@ -97,4 +97,5 @@ defmodule Mariaex.TestHelper do
   def length_encode_row(row) do
     Enum.map_join(row, &(<<String.length(&1)>> <> &1))
   end
+
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -66,6 +66,17 @@ defmodule Mariaex.TestHelper do
     end
   end
 
+  defmacro execute_text(stat, params, opts \\ []) do
+    quote do
+      case Mariaex.execute(var!(context)[:pid], %Mariaex.Query{type: :text, statement: unquote(stat)},
+            unquote(params), unquote(opts)) do
+        {:ok, %Mariaex.Result{rows: nil}} -> :ok
+        {:ok, %Mariaex.Result{rows: rows}} -> rows
+        {:error, %Mariaex.Error{} = err} -> err
+      end
+    end
+  end
+
   defmacro with_prepare!(name, stat, params, opts \\ []) do
     quote do
       conn = var!(context)[:pid]
@@ -81,5 +92,9 @@ defmodule Mariaex.TestHelper do
     Logger.remove_backend(:console)
     fun.()
     Logger.add_backend(:console, flush: true)
+  end
+
+  def length_encode_row(row) do
+    Enum.map_join(row, &(<<String.length(&1)>> <> &1))
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,7 +36,7 @@ cmds = [
 
 Enum.each(cmds, fn cmd ->
   {status, output} = run_cmd.(cmd)
-  IO.puts ""
+  IO.puts "--> #{output}"
 
   if status != 0 do
     IO.puts """

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -1,0 +1,96 @@
+defmodule TextQueryTest do
+  use ExUnit.Case, async: true
+  import Mariaex.TestHelper
+
+  setup do
+    opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
+    {:ok, pid} = Mariaex.Connection.start_link(opts)
+    drop = "DROP TABLE IF EXISTS test"
+    {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: drop}, [])
+    create = """
+    CREATE TABLE test (
+    id serial,
+    bools boolean,
+    bits bit(2),
+    varchars varchar(20),
+    texts text(20),
+    floats double,
+    ts timestamp,
+    dt datetime
+    )
+    """
+    {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: create}, [])
+    insert = """
+    INSERT INTO test (id, bools, bits, varchars, texts, floats, ts, dt)
+    VALUES
+    (1, true, b'10', 'hello', 'world', 1.1, '2016-09-26 16:36:06', '0001-01-01 00:00:00'),
+    (2, false, b'11', 'goodbye', 'earth', 1.2, '2016-09-26T16:36:07', '0001-01-01 00:00:01')
+    """
+    {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: insert}, [])
+    {:ok, [pid: pid]}
+  end
+
+  test "select int", context do
+    rows = execute_text("SELECT id FROM test", [])
+    assert(rows == [[1], [2]])
+  end
+
+  test "select bool", context do
+    # bool is tinyint
+    rows = execute_text("SELECT bools FROM test", [])
+    assert(rows == [[1], [0]])
+  end
+
+  test "select bits", context do
+    rows = execute_text("SELECT bits FROM test", [])
+    assert(rows == [[<<2>>], [<<3>>]])
+  end
+
+  test "select string", context do
+    rows = execute_text("SELECT floats FROM test", [])
+    assert(rows == [[1.1], [1.2]])
+  end
+
+  test "select float", context do
+    rows = execute_text("SELECT floats FROM test", [])
+    assert(rows == [[1.1], [1.2]])
+  end
+
+  test "select timestamp", context do
+    rows = execute_text("SELECT ts FROM test", [])
+    assert(rows == [[{{2016, 9, 26}, {16, 36, 06, 0}}], [{{2016, 9, 26}, {16, 36, 07, 0}}]])
+  end
+
+  test "select datetime", context do
+    rows = execute_text("SELECT dt FROM test", [])
+    assert(rows == [[{{1,1,1}, {0,0,0,0}}], [{{1,1,1}, {0,0,1,0}}]])
+  end
+
+  test "select multiple columns", context do
+    rows = execute_text("SELECT id, varchars FROM test", [])
+    assert(rows == [[1, "hello"], [2, "goodbye"]])
+  end
+
+  test "decode text row" do
+    # rows are consed onto the front, so they are backwards
+    rows = [["Goodbye", "2", "0.11111"],
+            ["Hello", "1", "2.0000"]] |> Enum.map(&(length_encode_row/1))
+    res = %Mariaex.Result{
+      columns: nil, command: nil, connection_id: nil, last_insert_id: nil, num_rows: nil, rows: rows}
+    types = [
+      %Mariaex.Column{flags: 0, name: "someFloat", table: "", type: 4},
+      %Mariaex.Column{flags: 0, name: "someInt", table: "", type: 2},
+      %Mariaex.Column{flags: 0, name: "someText", table: "", type: 254},
+    ]
+    qry = %Mariaex.Query{type: :text,
+                         statement: "SELECT someText, someInt, someFloat FROM someTable"}
+    obs = DBConnection.Query.decode(qry, {res, types}, [])
+    exp = %Mariaex.Result{res |
+                          rows: [["Hello", 1, 2.0000], ["Goodbye", 2, 0.11111]],
+                          columns: ["someText", "someInt", "someFloat"],
+                          num_rows: 2,
+                          command: :select}
+    assert(obs == exp)
+  end
+
+end

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -2,13 +2,13 @@ defmodule TextQueryTest do
   use ExUnit.Case, async: true
   import Mariaex.TestHelper
 
-  setup do
+  setup_all do
     opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
     {:ok, pid} = Mariaex.Connection.start_link(opts)
-    drop = "DROP TABLE IF EXISTS test"
-    {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: drop}, [])
+    # drop = "DROP TABLE IF EXISTS test"
+    # {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: drop}, [])
     create = """
-    CREATE TABLE test (
+    CREATE TABLE test_text_query_table (
     id serial,
     bools boolean,
     bits bit(2),
@@ -21,7 +21,7 @@ defmodule TextQueryTest do
     """
     {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: create}, [])
     insert = """
-    INSERT INTO test (id, bools, bits, varchars, texts, floats, ts, dt)
+    INSERT INTO test_text_query_table (id, bools, bits, varchars, texts, floats, ts, dt)
     VALUES
     (1, true, b'10', 'hello', 'world', 1.1, '2016-09-26 16:36:06', '0001-01-01 00:00:00'),
     (2, false, b'11', 'goodbye', 'earth', 1.2, '2016-09-26T16:36:07', '0001-01-01 00:00:01')
@@ -31,43 +31,43 @@ defmodule TextQueryTest do
   end
 
   test "select int", context do
-    rows = execute_text("SELECT id FROM test", [])
+    rows = execute_text("SELECT id FROM test_text_query_table", [])
     assert(rows == [[1], [2]])
   end
 
   test "select bool", context do
     # bool is tinyint
-    rows = execute_text("SELECT bools FROM test", [])
+    rows = execute_text("SELECT bools FROM test_text_query_table", [])
     assert(rows == [[1], [0]])
   end
 
   test "select bits", context do
-    rows = execute_text("SELECT bits FROM test", [])
+    rows = execute_text("SELECT bits FROM test_text_query_table", [])
     assert(rows == [[<<2>>], [<<3>>]])
   end
 
   test "select string", context do
-    rows = execute_text("SELECT floats FROM test", [])
+    rows = execute_text("SELECT floats FROM test_text_query_table", [])
     assert(rows == [[1.1], [1.2]])
   end
 
   test "select float", context do
-    rows = execute_text("SELECT floats FROM test", [])
+    rows = execute_text("SELECT floats FROM test_text_query_table", [])
     assert(rows == [[1.1], [1.2]])
   end
 
   test "select timestamp", context do
-    rows = execute_text("SELECT ts FROM test", [])
+    rows = execute_text("SELECT ts FROM test_text_query_table", [])
     assert(rows == [[{{2016, 9, 26}, {16, 36, 06, 0}}], [{{2016, 9, 26}, {16, 36, 07, 0}}]])
   end
 
   test "select datetime", context do
-    rows = execute_text("SELECT dt FROM test", [])
+    rows = execute_text("SELECT dt FROM test_text_query_table", [])
     assert(rows == [[{{1,1,1}, {0,0,0,0}}], [{{1,1,1}, {0,0,1,0}}]])
   end
 
   test "select multiple columns", context do
-    rows = execute_text("SELECT id, varchars FROM test", [])
+    rows = execute_text("SELECT id, varchars FROM test_text_query_table", [])
     assert(rows == [[1, "hello"], [2, "goodbye"]])
   end
 


### PR DESCRIPTION
The MySQL [text protocol COM_QUERY response](https://dev.mysql.com/doc/internals/en/com-query-response.html) is not supported. I needed to communicated with a MySQL-like implementation that only supported the text protocol, so I was running into #132.

This is my implementation of the text query response protocol. The difference between the binary and text protocols is that the text protocol converts all the row data to length encoded strings. I've made `Query.decode` dispatch on the query type, added more function clauses to `handle_text_query`, and added a bunch of string parsing for the `decode_text_rows` function.

I also have a few questions/concerns about my code:
- It seems like the `handle_text_query` function should be able to have more overlap with the `handle_binary_query` functions, but I'm not sure how that would work. It sure would be nice to DRY it up a bit.
- It would be nice _for my use case_ to pass query type (and whether or not to prepare the query) into `Mariaex.query` - does that seem like something that we could or should insert into the API?
