### PR TITLE
Update parsing of auth_plugin_data2 in MySQL handshake

### DIFF
--- a/lib/mariaex/coder.ex
+++ b/lib/mariaex/coder.ex
@@ -191,7 +191,7 @@ defmodule Mariaex.Coder do
                             << contents :: size(length_nul_terminated)-binary, 0 :: 8 >> -> contents
                             contents -> contents
                           end
-      {String.trim(auth_plugin_data2, <<0>>), next}
+      {String.strip(auth_plugin_data2, 0), next}
     end
 
     def length_encoded_string_eof(bin, acc \\ []) do

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -89,9 +89,8 @@ defmodule Mariaex.Messages do
     character_set 1
     status_flags 2
     capability_flags_2 2
-    length_auth_plugin_data 1
-    _ 10
-    auth_plugin_data2 :string #max(13, length_auth_plugin_data - 8), :string
+    # length_auth_plugin_data and the following ten bytes in the spec are rolled into the following field
+    auth_plugin_data2 :auth_plugin_data2  #max(13, length_auth_plugin_data - 8), :string
     plugin :string_eof
   end
 

--- a/test/coder_test.exs
+++ b/test/coder_test.exs
@@ -1,0 +1,46 @@
+defmodule CoderTest do
+  use ExUnit.Case, async: true
+  import Mariaex.Coder.Utils
+
+  test "auth_plugin_data2 understands null-terminated strings longer than 12 bytes" do
+    ten_bytes = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
+    auth_plugin_data2 = "12345678901234"
+    obs = auth_plugin_data2(<<23>> <> ten_bytes <> auth_plugin_data2 <> <<0>>)
+    assert({auth_plugin_data2, <<>>} == obs)
+  end
+
+  test "auth_plugin_data2 understands null-terminated strings equal to 12 bytes" do
+    ten_bytes = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
+    auth_plugin_data2 = "123456789012"
+    obs = auth_plugin_data2(<<20>> <> ten_bytes <> auth_plugin_data2 <> <<0>>)
+    assert({auth_plugin_data2, <<>>} == obs)
+  end
+
+  test "auth_plugin_data2 understands null-terminated strings shorter than 12 bytes" do
+    ten_bytes = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
+    auth_plugin_data2 = "1234567890"
+    obs = auth_plugin_data2(<<18>> <> ten_bytes <> auth_plugin_data2 <> <<0, 0, 0>>)
+    assert({auth_plugin_data2, <<>>} == obs)
+  end
+
+  test "auth_plugin_data2 understands fixlen strings longer than 13 bytes" do
+    ten_bytes = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
+    auth_plugin_data2 = "123456789012345"
+    obs = auth_plugin_data2(<<23>> <> ten_bytes <> auth_plugin_data2)
+    assert({auth_plugin_data2, <<>>} == obs)
+  end
+
+  test "auth_plugin_data2 understands fixlen strings equal to 13 bytes" do
+    ten_bytes = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
+    auth_plugin_data2 = "1234567890123"
+    obs = auth_plugin_data2(<<20>> <> ten_bytes <> auth_plugin_data2)
+    assert({auth_plugin_data2, <<>>} == obs)
+  end
+
+  test "auth_plugin_data2 understands fixlen strings shorter than 13 bytes" do
+    ten_bytes = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
+    auth_plugin_data2 = "1234567890"
+    obs = auth_plugin_data2(<<18>> <> ten_bytes <> auth_plugin_data2 <> <<0, 0, 0>>)
+    assert({auth_plugin_data2, <<>>} == obs)
+  end
+end


### PR DESCRIPTION
Hi! This is my fix for #133. 

I couldn't figure out a good way to put that dependency between `length_auth_plugin_data` and `auth_plugin_data2` in the spec. So I've made `auth_plugin_data2` something analogous to `length_encoded_string`, since the combination of `length_auth_plugin_data`, the following 10 bytes, and then `auth_plugin_data2` acts much like a length encoded string.

The MySQL spec doesn't mention what happens if `length_auth_plugin_data` is less than 21 - currently our implementation strips out any null bytes and hopes for the best. 