### PR TITLE
Performance enhancements

### DIFF
--- a/lib/mariaex/protocol_helper.ex
+++ b/lib/mariaex/protocol_helper.ex
@@ -3,7 +3,7 @@ defmodule Mariaex.ProtocolHelper do
     quote do
       defp unquote(recv_func)(state, request) do
         case msg_recv(state) do
-          {:ok, packet} ->
+          {:ok, packet, state} ->
             unquote(handle_func)(packet, request, state)
           {:error, reason} ->
             {sock_mod, _} = state.sock

--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -179,10 +179,12 @@ defimpl DBConnection.Query, for: Mariaex.Query do
       |> type_to_atom(column.flags)
     end)
 
+    nullbin_size = div(length(row_types) + 7 + 2, 8)
+
     rows
     |> Enum.reduce([], fn(row, acc) ->
       decoded_row = row
-      |> RowParser.decode_bin_rows(row_types)
+      |> RowParser.decode_bin_rows(row_types, nullbin_size)
       |> mapper.()
 
       [decoded_row | acc]

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -7,12 +7,7 @@ defmodule Mariaex.RowParser do
   """
   use Bitwise
 
-  def decode_bin_rows(packet, fields) do
-    nullbin_size = div(length(fields) + 7 + 2, 8)
-    decode_bin_rows(packet, fields, nullbin_size)
-  end
-
-  defp decode_bin_rows(packet, fields, nullbin_size) do
+  def decode_bin_rows(packet, fields, nullbin_size) do
     << 0 :: 8, null_bitfield :: size(nullbin_size)-little-unit(8), rest :: binary >> = packet
     decode_bin_rows(rest, fields, null_bitfield >>> 2, [])
   end

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -7,8 +7,6 @@ defmodule Mariaex.RowParser do
   """
   use Bitwise
 
-  @unsigned_flag 0x20
-
   def decode_bin_rows(packet, fields) do
     nullbin_size = div(length(fields) + 7 + 2, 8)
     decode_bin_rows(packet, fields, nullbin_size)
@@ -23,59 +21,75 @@ defmodule Mariaex.RowParser do
     decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc])
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:string, flags} | fields], null_bitfield,  acc) do
-    decode_string(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:string | fields], null_bitfield,  acc) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:int8, flags} | fields], null_bitfield, acc) do
-    decode_int8(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint8 | fields], null_bitfield, acc) do
+    decode_uint8(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:int16, flags} | fields], null_bitfield, acc) do
-    decode_int16(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int8 | fields], null_bitfield, acc) do
+    decode_int8(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:int32, flags} | fields], null_bitfield, acc) do
-    decode_int32(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint16 | fields], null_bitfield, acc) do
+    decode_uint16(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:int64, flags} | fields], null_bitfield, acc) do
-    decode_int64(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int16 | fields], null_bitfield, acc) do
+    decode_int16(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:year, flags} | fields], null_bitfield, acc) do
-    decode_int16(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint32 | fields], null_bitfield, acc) do
+    decode_uint32(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:time, flags} | fields], null_bitfield, acc) do
-    decode_time(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int32 | fields], null_bitfield, acc) do
+    decode_int32(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:date, flags} | fields], null_bitfield, acc) do
-    decode_date(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint64 | fields], null_bitfield, acc) do
+    decode_uint64(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:datetime, flags} | fields], null_bitfield, acc) do
-    decode_datetime(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int64 | fields], null_bitfield, acc) do
+    decode_int64(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:decimal, flags} | fields], null_bitfield, acc) do
-    decode_decimal(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:year | fields], null_bitfield, acc) do
+    decode_int16(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:float32, flags} | fields], null_bitfield, acc) do
-    decode_float32(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:time | fields], null_bitfield, acc) do
+    decode_time(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:float64, flags} | fields], null_bitfield, acc) do
-    decode_float64(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:date | fields], null_bitfield, acc) do
+    decode_date(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:bit, flags} | fields], null_bitfield, acc) do
-    decode_string(rest, flags, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:datetime | fields], null_bitfield, acc) do
+    decode_datetime(rest, fields, null_bitfield >>> 1, acc)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [{:nil, _flags} | fields], null_bitfield, acc) do
+  defp decode_bin_rows(<<rest::bits>>, [:decimal | fields], null_bitfield, acc) do
+    decode_decimal(rest, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [:float32 | fields], null_bitfield, acc) do
+    decode_float32(rest, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [:float64 | fields], null_bitfield, acc) do
+    decode_float64(rest, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [:bit | fields], null_bitfield, acc) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [:nil | fields], null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc])
   end
 
@@ -83,120 +97,120 @@ defmodule Mariaex.RowParser do
     Enum.reverse(acc)
   end
 
-  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, _flags, fields, nullint,  acc) when len <= 250 do
+  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) when len <= 250 do
     decode_bin_rows(rest, fields, nullint,  [string | acc])
   end
 
-  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, _flags, fields, nullint,  acc) do
+  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) do
     decode_bin_rows(rest, fields, nullint,  [string | acc])
   end
 
-  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, _flags, fields, nullint,  acc) do
+  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) do
     decode_bin_rows(rest, fields, nullint,  [string | acc])
   end
 
-  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>, _flags,  fields, nullint,  acc) do
+  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>,  fields, nullint,  acc) do
     decode_bin_rows(rest, fields, nullint,  [string | acc])
   end
 
-  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, _flags, fields, null_bitfield, acc) do
+  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [value | acc])
   end
 
-  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, _flags, fields, null_bitfield, acc) do
+  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [value | acc])
   end
 
-  defp decode_int8(<<value::size(8)-little-unsigned, rest::bits>>,
-                  flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+  defp decode_uint8(<<value::size(8)-little-unsigned, rest::bits>>,
+                    fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
   defp decode_int8(<<value::size(8)-little-signed, rest::bits>>,
-                  _flags, fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
-  defp decode_int16(<<value::size(16)-little-unsigned, rest::bits>>,
-                   flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+  defp decode_uint16(<<value::size(16)-little-unsigned, rest::bits>>,
+                     fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
   defp decode_int16(<<value::size(16)-little-signed, rest::bits>>,
-                   _flags, fields, null_bitfield, acc) do
+                    fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
-  defp decode_int32(<<value::size(32)-little-unsigned, rest::bits>>,
-                   flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+  defp decode_uint32(<<value::size(32)-little-unsigned, rest::bits>>,
+                     fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
   defp decode_int32(<<value::size(32)-little-signed, rest::bits>>,
-                   _flags, fields, null_bitfield, acc) do
+                    fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
-  defp decode_int64(<<value::size(64)-little-unsigned, rest::bits>>,
-                   flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+  defp decode_uint64(<<value::size(64)-little-unsigned, rest::bits>>,
+                     fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
   defp decode_int64(<<value::size(64)-little-signed, rest::bits>>,
-                   _flags, fields, null_bitfield, acc) do
+                    fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield , [value | acc])
   end
 
   defp decode_decimal(<<length,  raw_value::size(length)-little-binary, rest::bits>>,
-                     _flags, fields, null_bitfield, acc) do
+                      fields, null_bitfield, acc) do
     value = Decimal.new(raw_value)
     decode_bin_rows(rest, fields, null_bitfield, [value | acc])
   end
 
   defp decode_time(<< 0::8-little, rest::bits>>,
-                 _flags, fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc])
   end
 
   defp decode_time(<<8::8-little, _::8-little, _::32-little, hour::8-little, min::8-little, sec::8-little, rest::bits>>,
-                  _flags, fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc])
   end
 
   defp decode_time(<< 12::8, _::32-little, _::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                  _flags, fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc) do
 
     decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc])
   end
 
   defp decode_date(<< 0::8-little, rest::bits >>,
-                  _flags, fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc])
   end
 
   defp decode_date(<< 4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                  _flags, fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc) do
 
     decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc])
   end
 
   defp decode_datetime(<< 0::8-little, rest::bits >>,
-                      _flags, fields, null_bitfield, acc) do
+                       fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc])
   end
 
   defp decode_datetime(<<4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                      _flags, fields, null_bitfield, acc) do
+                       fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc])
   end
 
   defp decode_datetime(<< 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, rest::bits >>,
-                      _flags, fields, null_bitfield, acc) do
+                       fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc])
   end
 
   defp decode_datetime(<<11::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                      _flags, fields, null_bitfield, acc) do
+                       fields, null_bitfield, acc) do
     decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc])
   end
 end

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -1,0 +1,202 @@
+defmodule Mariaex.RowParser do
+  @moduledoc """
+  Parse a row of the MySQL protocol
+
+  This parser makes extensive use of binary pattern matching and recursion to take advantage
+  of Erlang's optimizer that will not create sub binaries when called recusively.
+  """
+  use Bitwise
+
+  @unsigned_flag 0x20
+
+  def decode_bin_rows(packet, fields) do
+    nullbin_size = div(length(fields) + 7 + 2, 8)
+    decode_bin_rows(packet, fields, nullbin_size)
+  end
+
+  defp decode_bin_rows(packet, fields, nullbin_size) do
+    << 0 :: 8, null_bitfield :: size(nullbin_size)-little-unit(8), rest :: binary >> = packet
+    decode_bin_rows(rest, fields, null_bitfield >>> 2, [])
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [_ | fields], nullint, acc) when (nullint &&& 1) === 1 do
+    decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc])
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:string, flags} | fields], null_bitfield,  acc) do
+    decode_string(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:int8, flags} | fields], null_bitfield, acc) do
+    decode_int8(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:int16, flags} | fields], null_bitfield, acc) do
+    decode_int16(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:int32, flags} | fields], null_bitfield, acc) do
+    decode_int32(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:int64, flags} | fields], null_bitfield, acc) do
+    decode_int64(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:year, flags} | fields], null_bitfield, acc) do
+    decode_int16(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:time, flags} | fields], null_bitfield, acc) do
+    decode_time(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:date, flags} | fields], null_bitfield, acc) do
+    decode_date(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:datetime, flags} | fields], null_bitfield, acc) do
+    decode_datetime(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:decimal, flags} | fields], null_bitfield, acc) do
+    decode_decimal(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:float32, flags} | fields], null_bitfield, acc) do
+    decode_float32(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:float64, flags} | fields], null_bitfield, acc) do
+    decode_float64(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:bit, flags} | fields], null_bitfield, acc) do
+    decode_string(rest, flags, fields, null_bitfield >>> 1, acc)
+  end
+
+  defp decode_bin_rows(<<rest::bits>>, [{:nil, _flags} | fields], null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc])
+  end
+
+  defp decode_bin_rows(<<>>, [], _, acc) do
+    Enum.reverse(acc)
+  end
+
+  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, _flags, fields, nullint,  acc) when len <= 250 do
+    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  end
+
+  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, _flags, fields, nullint,  acc) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  end
+
+  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, _flags, fields, nullint,  acc) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  end
+
+  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>, _flags,  fields, nullint,  acc) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  end
+
+  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+  end
+
+  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+  end
+
+  defp decode_int8(<<value::size(8)-little-unsigned, rest::bits>>,
+                  flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_int8(<<value::size(8)-little-signed, rest::bits>>,
+                  _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_int16(<<value::size(16)-little-unsigned, rest::bits>>,
+                   flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_int16(<<value::size(16)-little-signed, rest::bits>>,
+                   _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_int32(<<value::size(32)-little-unsigned, rest::bits>>,
+                   flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_int32(<<value::size(32)-little-signed, rest::bits>>,
+                   _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_int64(<<value::size(64)-little-unsigned, rest::bits>>,
+                   flags, fields, null_bitfield, acc) when (@unsigned_flag &&& flags) == @unsigned_flag do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_int64(<<value::size(64)-little-signed, rest::bits>>,
+                   _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+  end
+
+  defp decode_decimal(<<length,  raw_value::size(length)-little-binary, rest::bits>>,
+                     _flags, fields, null_bitfield, acc) do
+    value = Decimal.new(raw_value)
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+  end
+
+  defp decode_time(<< 0::8-little, rest::bits>>,
+                 _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc])
+  end
+
+  defp decode_time(<<8::8-little, _::8-little, _::32-little, hour::8-little, min::8-little, sec::8-little, rest::bits>>,
+                  _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc])
+  end
+
+  defp decode_time(<< 12::8, _::32-little, _::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
+                  _flags, fields, null_bitfield, acc) do
+
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc])
+  end
+
+  defp decode_date(<< 0::8-little, rest::bits >>,
+                  _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc])
+  end
+
+  defp decode_date(<< 4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
+                  _flags, fields, null_bitfield, acc) do
+
+    decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc])
+  end
+
+  defp decode_datetime(<< 0::8-little, rest::bits >>,
+                      _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc])
+  end
+
+  defp decode_datetime(<<4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
+                      _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc])
+  end
+
+  defp decode_datetime(<< 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, rest::bits >>,
+                      _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc])
+  end
+
+  defp decode_datetime(<<11::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
+                      _flags, fields, null_bitfield, acc) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc])
+  end
+end


### PR DESCRIPTION
I was selecting 300k rows to benchmark MariaEx against some of the competition, and it was very slow, routinely taking over seven seconds to complete the select. 

This PR focuses on the following areas:
* Networking
   - MariaEx was receiving a header packet and then receiving only the number of bytes required by the header. This causes many extra calls to the socket. This changes the behavior to read as much as possible and read packets from the buffer. 
* Binary pattern matching
  - The new RowDecoder module takes advantage of an optimization in Erlang where if you make recursive calls and the binary is in the first parameter, the runtime will not split the binary.
* Bit twiddling
  - Instead of throwing the null bitmap into a binary and peeling off bits from there, we throw it into an integer and shift the bits out. 

Taken together, these performance enhancements brought the time from 7200ms to 1620ms. 
There might be more optimizations that we can make, but I wanted to get this out there.

Thanks to @fishcakez for all the help here. He really deserves the credit for this. 