### PR TITLE
Improve prepared query handling

### DIFF
--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -239,6 +239,41 @@ defmodule Mariaex do
   end
 
   @doc """
+  Close a prepared a query and returns `:ok` or `{:error, %Mariaex.Error{}}` if
+  there was an error.
+
+  ## Options
+
+    * `:pool_timeout` - Time to wait in the queue for the connection
+    (default: `#{@pool_timeout}`)
+    * `:queue` - Whether to wait for connection in a queue (default: `true`);
+    * `:timeout` - Prepare request timeout (default: `#{@timeout}`);
+    * `:pool` - The pool module to use, must match that set on
+    `start_link/1`, see `DBConnection`
+
+  ## Examples
+
+      query = Mariaex.prepare!(conn, "SELECT id FROM posts WHERE title like $1")
+      Mariaex.close(conn, query)
+  """
+  @spec close(conn, Mariaex.Query.t, Keyword.t) :: :ok | {:error, Mariaex.Error.t}
+  def close(conn, query, opts \\ []) do
+    case DBConnection.close(conn, query, defaults(opts)) do
+      {:ok, _} -> :ok
+      other    -> arg_error_raiser(other)
+    end
+  end
+
+  @doc """
+  Close a prepared query and returns `:ok` or raises
+  `Mariaex.Error` if there was an error. See `close/3`.
+  """
+  @spec close!(conn, Mariaex.Query.t, Keyword.t) :: :ok
+  def close!(conn, query, opts \\ []) do
+    DBConnection.close!(conn, query, defaults(opts))
+  end
+
+  @doc """
   Acquire a lock on a connection and run a series of requests inside a
   transaction. The result of the transaction fun is return inside an `:ok`
   tuple: `{:ok, result}`.

--- a/lib/mariaex/lru_cache.ex
+++ b/lib/mariaex/lru_cache.ex
@@ -1,46 +1,83 @@
 defmodule Mariaex.LruCache do
-  @moduledoc """
-  Implements LRU cache for queries.
-  """
-  import :os, only: [timestamp: 0]
+  @moduledoc false
 
   def new(size) do
-    {size, :ets.new(:cache, [:public])}
+    tab = :ets.new(:cache, [:public])
+    :ets.insert(tab, {:__counter__, 0})
+    {size, tab}
   end
 
-  def lookup({_, cache}, statement) do
-    case :ets.lookup(cache, statement) do
-      [{_, _, info}] -> info
-      _ -> nil
-    end
-  end
-
-  def delete({_, cache}, statement, cleanup) do
-    case :ets.lookup(cache, statement) do
-      [{_, _, info}] ->
-        :ets.delete(cache, statement)
-        cleanup.(statement, info)
-      _ ->
+  def types({_, cache}, statement) do
+    case :ets.match(cache, {statement, :_, :_, :"$1", :"$2"}) do
+      [[ref, types]] ->
+        increment(cache, statement)
+        {ref, types}
+      [] ->
         nil
     end
   end
 
-  def insert({size, cache}, statement, data, cleanup) do
-    if :ets.info(cache, :size) > size, do: remove_oldest(cache, cleanup)
-    :ets.insert(cache, {statement, timestamp(), data})
+  def id({_, cache}, statement) do
+    try do
+      :ets.lookup_element(cache, statement, 3)
+    catch
+      :error, :badarg ->
+        nil
+    end
   end
 
-  def update({_, cache}, statement, data) do
-    :ets.insert(cache, {statement, timestamp(), data})
+  def lookup({_, cache}, statement) do
+    case :ets.match(cache, {statement, :_, :"$1", :"$2", :_}) do
+      [[id, ref]] ->
+        increment(cache, statement)
+        {id, ref}
+      [] ->
+        nil
+    end
   end
 
-  defp remove_oldest(cache, cleanup) do
-    {statement, _, data} = :ets.foldl(fn({statement, timestamp, data}, nil) ->
-                                          {statement, timestamp, data}
-                                        ({_, timestamp, _} = actual, {_, acc_timestamp, _} = acc) ->
-                                          if timestamp < acc_timestamp do actual else acc end
-                                      end, nil, cache)
-    cleanup.(statement, data)
+  def garbage_collect({size, cache}) do
+    if :ets.info(cache, :size) >= size do
+      take_oldest(cache)
+    end
+  end
+
+  def take({_, cache}, statement) do
+    try do
+      :ets.lookup_element(cache, statement, 3)
+    catch
+      :error, :badarg ->
+        nil
+    else
+      id ->
+        :ets.delete(cache, statement)
+        id
+    end
+  end
+
+  def insert_new({_, cache}, statement, id, ref, types) do
+    :ets.insert_new(cache, {statement, increment(cache), id, ref, types})
+  end
+
+  def delete({_, cache}, statement) do
     :ets.delete(cache, statement)
+  end
+
+  defp take_oldest(cache) do
+    {statement, _, id, _} = :ets.foldl(fn(actual, nil) ->
+                                          actual
+                                         ({_, counter, _, _, _} = actual, {_, min, _, _, _} = acc) ->
+                                          if counter < min do actual else acc end
+                                      end, nil, cache)
+    :ets.delete(cache, statement)
+    id
+  end
+
+  defp increment(cache, statement) do
+    :ets.update_element(cache, statement, {2, increment(cache)})
+  end
+
+  defp increment(cache) do
+    :ets.update_counter(cache, :__counter__, {2, 1})
   end
 end

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -40,7 +40,6 @@ defmodule Mariaex.Protocol do
                 @client_deprecate_eof
 
   defstruct sock: nil,
-            connection_ref: nil,
             state: nil,
             state_data: nil,
             protocol57: false,
@@ -75,7 +74,6 @@ defmodule Mariaex.Protocol do
                         state: :handshake,
                         ssl_conn_state: set_initial_ssl_conn_state(opts),
                         connection_id: self(),
-                        connection_ref: make_ref(),
                         sock: {sock_mod, sock},
                         cache: Cache.new(),
                         lru_cache: LruCache.new(opts[:cache_size]),
@@ -285,31 +283,14 @@ defmodule Mariaex.Protocol do
   def handle_prepare(%Query{type: :text} = query, _, s) do
     {:ok, query, s}
   end
-  def handle_prepare(%Query{type: :binary, statement: statement} = query, _, %{connection_ref: ref} = s) do
-    case cache_lookup(query, s) do
-      {id, types, parameter_types} ->
-        {:ok, %{query | binary_as: s.binary_as, statement_id: id, types: types, parameter_types: parameter_types, connection_ref: ref}, s}
-      nil ->
-        msg_send(text_cmd(command: com_stmt_prepare(), statement: statement), s, 0)
-        prepare_recv(%{s | binary_as: s.binary_as, state: :prepare_send}, query)
-    end
-  end
-
-  defp cache_lookup(%Query{name: "", statement: statement}, %{lru_cache: lru_cache}) do
-    case LruCache.lookup(lru_cache, statement) do
-      {_id, _types, _parameter_types} = result ->
-        LruCache.update(lru_cache, statement, result)
-        result
-      nil ->
-        nil
-    end
-  end
-  defp cache_lookup(%Query{name: name}, %{cache: cache}) do
-    case Cache.lookup(cache, name) do
-      {_id, _types, _parameter_types} = result ->
-        result
-      nil ->
-        nil
+  def handle_prepare(%Query{type: :binary} = query, _, s) do
+    case prepare_lookup(query, s) do
+      {:prepared, query} ->
+        {:ok, query, s}
+      {:prepare, query} ->
+        prepare(query, s)
+      {:close_prepare, id, query} ->
+        close_prepare(id, query, s)
     end
   end
 
@@ -321,20 +302,51 @@ defmodule Mariaex.Protocol do
     end
   end
 
+  defp prepare_lookup(%Query{name: "", statement: statement} = query, %{lru_cache: cache}) do
+    case LruCache.types(cache, statement) || LruCache.garbage_collect(cache) do
+      {ref, {types, parameter_types}} ->
+        {:prepared, %{query | ref: ref, types: types, parameter_types: parameter_types}}
+      id when is_integer(id) ->
+        {:close_prepare, id, query}
+      nil ->
+        {:prepare, query}
+    end
+  end
+  defp prepare_lookup(%Query{name: name} = query, %{cache: cache}) do
+    case Cache.take(cache, name) do
+      id when is_integer(id) ->
+        {:close_prepare, id, query}
+      nil ->
+        {:prepare, query}
+    end
+  end
+
+  defp prepare(%Query{statement: statement} = query, s) do
+    msg_send(text_cmd(command: com_stmt_prepare(), statement: statement), s, 0)
+    prepare_recv(%{s | state: :prepare_send}, query)
+  end
+
+  defp close_prepare(id, %Query{statement: statement} = query, s) do
+    msgs = [stmt_close(command: com_stmt_close(), statement_id: id),
+            text_cmd(command: com_stmt_prepare(), statement: statement)]
+    msg_send(msgs, s, 0)
+    prepare_recv(%{s | state: :prepare_send}, query)
+  end
+
   def_handle :prepare_recv, :handle_prepare_send
   defp handle_prepare_send(packet(msg: stmt_prepare_ok(statement_id: id, num_columns: 0, num_params: 0)), query, state) do
-    prepare_may_recv_more(%{state | state_data: {0, 0}, catch_eof: false}, %{query | statement_id: id})
+    prepare_may_recv_more(%{state | state_data: {id, 0, 0}, catch_eof: false}, query)
   end
   defp handle_prepare_send(packet(msg: stmt_prepare_ok(statement_id: id, num_columns: columns, num_params: params)), query, state) do
-    statedata = {columns, params}
-    prepare_may_recv_more(%{state | state: :column_definitions, catch_eof: not state.protocol57, state_data: statedata}, %{query | statement_id: id})
+    statedata = {id, columns, params}
+    prepare_may_recv_more(%{state | state: :column_definitions, catch_eof: not state.protocol57, state_data: statedata}, query)
   end
   defp handle_prepare_send(packet(msg: column_definition_41() = msg), query, state) do
     query = add_column(query, msg)
     {query, state} = count_down(query, state)
     prepare_may_recv_more(state, query)
   end
-  defp handle_prepare_send(packet(msg: eof_resp()), query, %{state_data: {0, 0}} = state) do
+  defp handle_prepare_send(packet(msg: eof_resp()), query, %{state_data: {_, 0, 0}} = state) do
     prepare_may_recv_more(%{state | catch_eof: false}, query)
   end
   defp handle_prepare_send(packet(msg: eof_resp()), query, state) do
@@ -342,28 +354,30 @@ defmodule Mariaex.Protocol do
   end
   defp handle_prepare_send(packet, query, state), do: handle_error(packet, query, state)
 
-  defp prepare_may_recv_more(%{state_data: {0, 0}, catch_eof: false, connection_ref: ref} = state, query) do
-    cache_insert(query, state)
-    {:ok, %{query | connection_ref: ref}, clean_state(state)}
+  defp prepare_may_recv_more(%{state_data: {id, 0, 0}, catch_eof: false} = state, query) do
+    {:ok, prepare_insert(id, query, state), clean_state(state)}
   end
   defp prepare_may_recv_more(state, query) do
     prepare_recv(%{state | state: :column_definitions}, query)
   end
 
-  defp cache_insert(%{name: ""} = query, %{sock: sock, lru_cache: cache}) do
-    %{statement_id: id, statement: statement, types: types, parameter_types: parameter_types} = query
-    LruCache.insert(cache, statement, {id, types, parameter_types}, &close_statement(&1, &2, sock))
+  defp prepare_insert(id, %Query{name: "", statement: statement, ref: ref, types: types, parameter_types: parameter_types} = query, %{lru_cache: cache}) do
+    ref = ref || make_ref()
+    true = LruCache.insert_new(cache, statement, id, ref, {types, parameter_types})
+    %{query | ref: ref}
   end
-  defp cache_insert(%{name: name, statement_id: id, types: types, parameter_types: parameter_types}, %{cache: cache}) do
-    Cache.insert(cache, name, {id, types, parameter_types})
+  defp prepare_insert(id, %Query{name: name, ref: ref} = query, %{cache: cache}) do
+    ref= ref || make_ref()
+    true = Cache.insert_new(cache, name, id, ref)
+    %{query | ref: ref}
   end
 
-  defp count_down(query, s = %{state_data: {columns, params}}) when params > 1,
-    do: {query, %{s | state_data: {columns, params - 1}}}
-  defp count_down(query = %{types: definitions}, s = %{state_data: {columns, 1}}),
-    do: {%{query | types: [], parameter_types: Enum.reverse(definitions)}, %{s | state_data: {columns, 0}}}
-  defp count_down(query, s = %{state_data: {columns, 0}}),
-    do: {query, %{s | state_data: {columns - 1, 0}}}
+  defp count_down(query, s = %{state_data: {id, columns, params}}) when params > 1,
+    do: {query, %{s | state_data: {id, columns, params - 1}}}
+  defp count_down(query = %{types: definitions}, s = %{state_data: {id, columns, 1}}),
+    do: {%{query | types: [], parameter_types: Enum.reverse(definitions)}, %{s | state_data: {id, columns, 0}}}
+  defp count_down(query, s = %{state_data: {id, columns, 0}}),
+    do: {query, %{s | state_data: {id, columns - 1, 0}}}
 
   @doc """
   DBConnection callback
@@ -374,20 +388,71 @@ defmodule Mariaex.Protocol do
   def handle_execute(%Query{type: :text, statement: statement} = query, [], _opts, state) do
     send_text_query(state, statement) |> text_query_recv(query)
   end
-  def handle_execute(%Query{type: :binary, statement_id: id, connection_ref: ref} = query, params, _opts, %{connection_ref: ref} = state) do
-    msg_send(stmt_execute(command: com_stmt_execute(), parameters: params, statement_id: id, flags: 0, iteration_count: 1), state, 0)
-    binary_query_recv(%{state | state: :column_count}, query)
-  end
-  def handle_execute(%Query{type: :binary} = query, params, opts, state) do
-    case handle_prepare(query, opts, state) do
-      {:ok, query, state} ->
-        handle_execute(query, params, opts, state)
-      error ->
-        error
+  def handle_execute(%Query{type: :binary} = query, params, _, state) do
+    case execute_lookup(query, state) do
+      {:execute, id, query} ->
+        execute(id, query, params, state)
+      {:prepare_execute, query} ->
+        prep = %Query{query | types: [], parameter_types: []}
+        prepare_execute(&prepare(prep, &1), query, params, state)
+      {:close_prepare_execute, id, query} ->
+        prep = %Query{query | types: [], parameter_types: []}
+        prepare_execute(&close_prepare(id, prep, &1), query, params, state)
     end
   end
   def handle_execute(query, params, _opts, state) do
     query_error(state, "unsupported parameterized query #{inspect(query.statement)} parameters #{inspect(params)}")
+  end
+
+  defp execute_lookup(%Query{name: ""} = query, %{lru_cache: cache}) do
+    %Query{statement: statement, ref: ref} = query
+    case LruCache.lookup(cache, statement) || LruCache.garbage_collect(cache) do
+      {id, ^ref} ->
+        {:execute, id, query}
+      {id, _} ->
+        LruCache.delete(cache, statement)
+        {:close_prepare_execute, id, query}
+      id when is_integer(id) ->
+        {:close_prepare_execute, id, query}
+      nil ->
+        {:prepare_execute, query, query}
+    end
+  end
+  defp execute_lookup(%Query{name: name, ref: ref} = query, %{cache: cache}) do
+    case Cache.lookup(cache, name) do
+      {id, ^ref} ->
+        {:execute, id, query}
+      {id, _} ->
+        Cache.delete(cache, name)
+        {:close_prepare_execute, id, query}
+      nil ->
+        {:prepare_execute, query}
+    end
+  end
+
+  defp execute(id, query, params, state) do
+    msg_send(stmt_execute(command: com_stmt_execute(), parameters: params, statement_id: id, flags: 0, iteration_count: 1), state, 0)
+    binary_query_recv(%{state | state: :column_count}, query)
+  end
+
+  defp prepare_execute(prepare, query, params, state) do
+    %Query{types: types, parameter_types: parameter_types} = query
+    case prepare.(state) do
+      {:ok, %Query{types: ^types, parameter_types: ^parameter_types}, state} ->
+        id = prepare_execute_lookup(query, state)
+        execute(id, query, params, state)
+      {:ok, _, state} ->
+        stale_error(query, state)
+      {err, _, _} = error when err in [:error, :disconnect] ->
+        error
+    end
+  end
+
+  defp prepare_execute_lookup(%Query{name: "", statement: statement}, %{lru_cache: cache}) do
+    LruCache.id(cache, statement)
+  end
+  defp prepare_execute_lookup(%Query{name: name}, %{cache: cache}) do
+    Cache.id(cache, name)
   end
 
   def_handle :text_query_recv, :handle_text_query
@@ -400,12 +465,12 @@ defmodule Mariaex.Protocol do
 
   def_handle :binary_query_recv, :handle_binary_query
   defp handle_binary_query(packet(msg: column_count(column_count: count)), query, state) do
-    binary_query_recv(%{state | state: :column_definitions, state_data: {count, 0}}, %{query | types: []})
+    binary_query_recv(%{state | state: :column_definitions, state_data: {nil, count, 0}}, %{query | types: []})
   end
   defp handle_binary_query(packet(msg: column_definition_41() = msg), query, s) do
     query = add_column(query, msg)
     {query, s} = count_down(query, s)
-    s = if s.state_data == {0, 0}, do: %{s | state: :bin_rows, catch_eof: not s.protocol57}, else: s
+    s = if s.state_data == {nil, 0, 0}, do: %{s | state: :bin_rows, catch_eof: not s.protocol57}, else: s
     binary_query_recv(s, query)
   end
   defp handle_binary_query(packet(msg: eof_resp()), %{statement: statement} = query, s = %{catch_eof: catch_eof, state: :bin_rows}) do
@@ -438,7 +503,43 @@ defmodule Mariaex.Protocol do
   end
 
   defp clean_state(state) do
-    %{state | state: :running, rows: []}
+    %{state | state: :running, state_data: nil, rows: []}
+  end
+
+  @doc """
+  DBConnection callback
+  """
+  def handle_close(%Query{name: @reserved_prefix <> _ , reserved?: false} = query, _, s) do
+    reserved_error(query, s)
+  end
+  def handle_close(%Query{type: :text}, _, s) do
+    {:ok, nil, s}
+  end
+  def handle_close(%Query{type: :binary} = query, _, s) do
+    case close_lookup(query, s) do
+      {:close, id} ->
+        msg_send(stmt_close(command: com_stmt_close(), statement_id: id), s, 0)
+        {:ok, nil, s}
+      :closed ->
+        {:ok, nil, s}
+    end
+  end
+
+  defp close_lookup(%Query{name: "", statement: statement}, %{lru_cache: cache}) do
+    case LruCache.take(cache, statement) do
+      id when is_integer(id) ->
+        {:close, id}
+      nil ->
+        :closed
+    end
+  end
+  defp close_lookup(%Query{name: name}, %{cache: cache}) do
+    case Cache.take(cache, name) do
+      id when is_integer(id) ->
+        {:close, id}
+      nil ->
+        :closed
+    end
   end
 
   @doc """
@@ -654,23 +755,23 @@ defmodule Mariaex.Protocol do
     abort_statement(s, query, %Mariaex.Error{mariadb: %{code: code, message: message}})
   end
   defp abort_statement(s, query, error = %Mariaex.Error{}) do
-    {:error, error, close_statement(s, query)}
-  end
-
-  def close_statement(_statement, {id, _, _}, sock) do
-    msg_send(stmt_close(command: com_stmt_close(), statement_id: id), sock, 0)
-  end
-
-  def close_statement(s = %{sock: sock, lru_cache: cache}, %{statement: statement}) do
-    LruCache.delete(cache, statement, &close_statement(&1, &2, sock))
-    clean_state(s)
-  end
-  def close_statement(s = %{}, _) do
-    clean_state(s)
+    case query do
+      %Query{} ->
+        {:ok, nil, s} = handle_close(query, [], s)
+        {:error, error, clean_state(s)}
+      nil ->
+        {:error, error, clean_state(s)}
+    end
   end
 
   defp reserved_error(query, s) do
     error = ArgumentError.exception("query #{inspect query} uses reserved name")
+    {:error, error, s}
+  end
+
+  defp stale_error(query, s) do
+    {:ok, nil, s} = handle_close(query, [], s)
+    error = ArgumentError.exception("query #{inspect query} has stale types")
     {:error, error, s}
   end
 

--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -10,6 +10,7 @@ defmodule Mariaex.Query do
     * `result_formats` - List of formats for each column is decoded from;
     * `decoders` - List of anonymous functions to decode each column;
     * `types` - The type server table to fetch the type information from;
+    * `ref` - Reference that uniquely identifies when the query was prepared;
   """
 
   defstruct name: "",
@@ -17,10 +18,9 @@ defmodule Mariaex.Query do
             binary_as: nil,
             type: nil,
             statement: "",
-            statement_id: nil,
             parameter_types: [],
             types: [],
-            connection_ref: nil
+            ref: nil
 end
 
 defimpl DBConnection.Query, for: Mariaex.Query do
@@ -37,7 +37,7 @@ defimpl DBConnection.Query, for: Mariaex.Query do
 
   This function is called to parse a query term before it is prepared.
   """
-  def parse(%{name: name, statement: statement} = query, _) do
+  def parse(%{name: name, statement: statement, ref: nil} = query, _) do
     %{query | name: IO.iodata_to_binary(name), statement: IO.iodata_to_binary(statement)}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Mariaex.Mixfile do
 
   defp deps do
     [{:decimal, "~> 1.0"},
-     {:db_connection, "~> 1.0.0-rc"},
+     {:db_connection, "~> 1.0"},
      {:coverex, "~> 1.4.3", only: :test}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "coverex": {:hex, :coverex, "1.4.3", "c9e5520ac10c4eccaa0611605ddf769e50079ca348060329b698db3b058c2720", [:mix], [{:httpoison, "0.7.2", [hex: :httpoison, optional: false]}, {:poison, "~> 1.4.0", [hex: :poison, optional: false]}]},
-  "db_connection": {:hex, :db_connection, "1.0.0-rc.0", "debd4f4c126bf4cb3b984c82096cee15b18c18ecf339631e1105122dc4b59111", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.2", [hex: :sbroker, optional: true]}]},
+  "db_connection": {:hex, :db_connection, "1.0.0", "63c03e520d54886a66104d34e32397ba960db6e74b596ce221592c07d6a40d8d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.0", "3333732f17a90ff3057d7ab8c65f0930ca2d67e15cca812a91ead5633ed472fe", [:mix], []},
   "hackney": {:hex, :hackney, "1.3.2", "43bd07ab88753f5e136e38fddd2a09124bee25733b03361eeb459d0173fc17ab", [:rebar, :make], [{:idna, "~> 1.0.2", [hex: :idna, optional: false]}, {:ssl_verify_hostname, "~> 1.0.5", [hex: :ssl_verify_hostname, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.7.2", "e13ab8c056481b83aebe225fbc2260c3dfeac4d7271e9af80f234e3186fa843b", [:mix], [{:hackney, "~> 1.3.1", [hex: :hackney, optional: false]}]},

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -13,10 +13,49 @@ defmodule PreparedQueryTest do
     assert with_prepare!("test", "SELECT * FROM prepared_test", []) == []
   end
 
-  test "unprepared query should work", context do
+  test "executing query with incorrect types raises", context do
     :ok = query("CREATE TABLE unprepared_test (id int, text text)", [])
     conn = context[:pid]
     query = %Mariaex.Query{type: :binary, name: "unprepared_test", statement: "SELECT * FROM unprepared_test"}
-    assert %{rows: []} = Mariaex.execute!(conn, query, [])
+    assert_raise ArgumentError, ~r"stale type", fn() -> Mariaex.execute!(conn, query, []) end
+  end
+
+  test "prepare, execute and close", context do
+    assert (%Mariaex.Query{} = query) = prepare("42", "SELECT 42")
+    assert [[42]] = execute(query, [])
+    assert [[42]] = execute(query, [])
+    assert :ok = close(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "prepare query and execute different queries with same name", context do
+    query42 = prepare("select", "SELECT 42")
+    assert close(query42) == :ok
+    assert %Mariaex.Query{} = prepare("select", "SELECT 41")
+    assert [[42]] = execute(query42, [])
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "prepare, close and execute", context do
+    query = prepare("reuse", "SELECT ? + ?")
+    assert [[40]] = execute(query, [13, 27])
+    assert :ok = close(query)
+    assert [[40]] = execute(query, [3, 37])
+  end
+
+  test "closing prepared query that does not exist succeeds", context do
+    query = prepare("42", "SELECT 42")
+    assert :ok = close(query)
+    assert :ok = close(query)
+  end
+
+  test "execute and query the same unnamed statement", context do
+    query1 = prepare("", "SELECT 42")
+    assert :ok = close(query1)
+    query2 = prepare("", "SELECT 42")
+    assert [[42]] = execute(query2, [])
+    assert [[42]] = query("SELECT 42", [])
+    assert [[42]] = execute(query1, [])
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -77,6 +77,35 @@ defmodule Mariaex.TestHelper do
     end
   end
 
+  defmacro prepare(stat, opts \\ []) do
+    quote do
+      case Mariaex.prepare(var!(context)[:pid], unquote(stat), unquote(opts)) do
+        {:ok, %Mariaex.Query{} = query} -> query
+        {:error, %Mariaex.Error{} = err} -> err
+      end
+    end
+  end
+
+  defmacro execute(query, params, opts \\ []) do
+    quote do
+      case Mariaex.execute(var!(context)[:pid], unquote(query), unquote(params),
+                           unquote(opts)) do
+        {:ok, %Mariaex.Result{rows: nil}} -> :ok
+        {:ok, %Mariaex.Result{rows: rows}} -> rows
+        {:error, %Mariaex.Error{} = err} -> err
+      end
+    end
+  end
+
+  defmacro close(query, opts \\ []) do
+    quote do
+      case Mariaex.close(var!(context)[:pid], unquote(query), unquote(opts)) do
+        :ok -> :ok
+        {:error, %Mariaex.Error{} = err} -> err
+      end
+    end
+  end
+
   def capture_log(fun) do
     Logger.remove_backend(:console)
     fun.()


### PR DESCRIPTION
* Use references to uniquely identify named queries so that types/statement can be stored in query structs.
* Check the types match when implicitly preparing a query during execute phase.
* Don't leak the statement id outside a connection.
* Close always closes matching query name or statement if empty name.
* LRU cache closes queries before preparing one over the limit.