### PR TITLE
Cleanup query prepare/execute/stream

### DIFF
--- a/lib/mariaex/cache.ex
+++ b/lib/mariaex/cache.ex
@@ -16,8 +16,8 @@ defmodule Mariaex.Cache do
 
   def lookup(cache, name) do
     case :ets.match(cache, {name, :"$1", :"$2"}) do
-      [[id, types]] ->
-        {id, types}
+      [[id, ref]] ->
+        {id, ref}
       [] ->
         nil
     end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -497,7 +497,7 @@ defmodule QueryTest do
   end
 
   test "encoding bad parameters", context do
-    assert %ArgumentError{message: "parameters must be of length 1 for query" <> _} = catch_error(query("SELECT 1", [:badparam]))
+    assert %ArgumentError{message: "parameters must be of length 0 for query" <> _} = catch_error(query("SELECT 1", [:badparam]))
     assert %ArgumentError{message: "query has invalid parameter :badparam"} = catch_error(query("SELECT ?", [:badparam]))
   end
 


### PR DESCRIPTION
* Remove parameter_types and types from query struct
* Use with for flow control
* Use status flags to detect extra ok response
* Use cursor flags on execute