### PR TITLE
JR: Fix error when executing a stored procedure that does not return any results

### DIFF
--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -131,6 +131,10 @@ defimpl DBConnection.Query, for: Mariaex.Query do
   @unsigned_flag 0x20
 
   def decode(_, %{rows: nil} = res, _), do: res
+  def decode(%Mariaex.Query{statement: statement}, {res, nil}, _) do
+    command = Mariaex.Protocol.get_command(statement)
+    %Mariaex.Result{res | command: command, rows: nil}
+  end
   def decode(%Mariaex.Query{statement: statement}, {res, types}, opts) do
     command = Mariaex.Protocol.get_command(statement)
     if command in @commands_without_rows do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -548,6 +548,34 @@ defmodule QueryTest do
     assert query("DESCRIBE test_describe", []) == [["id", "int(11)", "YES", "", nil, ""]]
   end
 
+  test "execute call procedure stream", context do
+    sql =
+      """
+      CREATE PROCEDURE queryproc (IN a INT, IN b INT)
+      BEGIN
+      SELECT a + b;
+      END
+      """
+    assert :ok = query(sql, [])
+    assert query("CALL queryproc(1, 2)", []) == [[3]]
+  end
+
+  test "execute call procedure stream without results", context do
+    assert :ok = query("CREATE TABLE test_command_proc (id int)", [])
+    assert :ok = query("INSERT INTO test_command_proc VALUES(1)", [])
+    assert query("SELECT COUNT(*) FROM test_command_proc", []) == [[1]]
+    sql =
+      """
+      CREATE PROCEDURE commandproc ()
+      BEGIN
+      DELETE FROM test_command_proc;
+      END
+      """
+    assert :ok = query(sql, [])
+    assert :ok = query("CALL commandproc()", [])
+    assert query("SELECT COUNT(*) FROM test_command_proc", []) == [[0]]
+  end
+
   test "replace statement", context do
     date = {2014, 8, 20}
     timestamp = {date, {18, 47, 42, 0}}


### PR DESCRIPTION
Added 2 tests to query_tests.exs. In the current version of master, the first test would pass but the second test would not.

The change to query.ex makes both tests pass.