### PR TITLE
add support for non-microsecond datetimes

### DIFF
--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -118,6 +118,8 @@ defimpl DBConnection.Query, for: Mariaex.Query do
     do: {0, :field_type_time, << 8 :: 8-little, 0 :: 8-little, 0 :: 32-little, hour :: 8-little, min :: 8-little, sec :: 8-little >>}
   defp encode_param({hour, min, sec, msec}, _binary_as),
     do: {0, :field_type_time, << 12 :: 8-little, 0 :: 8-little, 0 :: 32-little, hour :: 8-little, min :: 8-little, sec :: 8-little, msec :: 32-little>>}
+  defp encode_param({{year, month, day}, {hour, min, sec}}, _binary_as),
+    do: {0, :field_type_datetime, << 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little>>}
   defp encode_param({{year, month, day}, {hour, min, sec, 0}}, _binary_as),
     do: {0, :field_type_datetime, << 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little>>}
   defp encode_param({{year, month, day}, {hour, min, sec, msec}}, _binary_as),

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -266,18 +266,21 @@ defmodule QueryTest do
     date = {2010, 10, 17}
     datetime = {date, {10, 10, 30, 0}}
     datetime_with_msec = {date, {13, 32, 15, 12}}
+    datetime_no_msec = {date, {10, 10, 29}}
     table = "test_datetimes"
 
-    sql = ~s{CREATE TABLE #{table} (id int, dt1 datetime, dt2 datetime)}
+    sql = ~s{CREATE TABLE #{table} (id int, dt1 datetime, dt2 datetime, dt3 datetime)}
     :ok = query(sql, [])
 
-    insert = ~s{INSERT INTO #{table} (id, dt1, dt2) VALUES (?, ?, ?)}
-    :ok = query(insert, [1, datetime, datetime_with_msec])
+    insert = ~s{INSERT INTO #{table} (id, dt1, dt2, dt3) VALUES (?, ?, ?, ?)}
+    :ok = query(insert, [1, datetime, datetime_with_msec, datetime_no_msec])
 
     # Datetime
     # Only MySQL 5.7 supports microseconds storage, so it will return 0 here
     assert query("SELECT dt1, dt2 FROM #{table} WHERE id = 1", []) == [[datetime, {date, {13, 32, 15, 0}}]]
     assert query("SELECT dt1, dt2 FROM #{table} WHERE id = ?", [1]) == [[datetime, {date, {13, 32, 15, 0}}]]
+    assert query("SELECT dt3 FROM #{table} WHERE id = ?", [1]) == [[{date, {10, 10, 29, 0}}]]
+    assert query("SELECT COUNT(*) FROM #{table} WHERE dt3 = ?", [datetime_no_msec]) == [[1]]
   end
 
   test "encode and decode timestamp", context do


### PR DESCRIPTION
Attempting to pass a normal `:calendar.datetime()` (`{{year, month, day}, {hour, min, sec}}`) as a parameter leads to a crash -- in `query.ex` `encode_param` is expecting the time part to include microseconds. This patch adds support for this form.

While it's a little weird for this to not be symmetric with decoding (it will always decode with the microseconds portion), it seemed like there might be too much guesswork involved, so I didn't touch decoding.