### PR TITLE
Added the 'GRANT' query to the @commands_without_rows list

### DIFF
--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -128,7 +128,7 @@ defimpl DBConnection.Query, for: Mariaex.Query do
 
   @commands_without_rows [:create, :insert, :replace, :update, :delete, :set,
                           :alter, :rename, :drop, :begin, :commit, :rollback,
-                          :savepoint, :execute, :prepare, :truncate]
+                          :savepoint, :execute, :prepare, :truncate, :grant]
 
   def decode(%Mariaex.Query{statement: statement}, {res, nil}, _) do
     command = Mariaex.Protocol.get_command(statement)


### PR DESCRIPTION
As the title suggests adds the GRANT keyword to the @commands_without_rows list.
This would raise an exception:

```
iex(1)> Mariaex.query(pid, "GRANT ALL PRIVILEGES ON test.* TO 'test'@'localhost'")
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
           (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
           (elixir) lib/enum.ex:116: Enumerable.reduce/3
           (elixir) lib/enum.ex:1776: Enum.reverse/2
          (mariaex) lib/mariaex/query.ex:147: DBConnection.Query.Mariaex.Query.decode/3
    (db_connection) lib/db_connection.ex:799: DBConnection.decode/6
          (mariaex) lib/mariaex.ex:142: Mariaex.query/4
```