### PR TITLE
Add json column support for mysql5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ notifications:
 sudo: false
 env:
     matrix:
-        - DB=mariadb:10.1
-        - DB=mariadb:10.2
-        - DB=mariadb:10.3
-        - DB=mysql:8.0
-        - DB=mysql:5.7
-        - DB=mysql:5.6
+        - DB=mariadb:10.1 MYSQL_5_7=false
+        - DB=mariadb:10.2 MYSQL_5_7=false
+        - DB=mariadb:10.3 MYSQL_5_7=false
+        - DB=mysql:8.0 MYSQL_5_7=true
+        - DB=mysql:5.7 MYSQL_5_7=true
+        - DB=mysql:5.6 MYSQL_5_7=false
 before_install:
     - sudo service mysql stop
     - docker pull $DB || true
     - docker run --name mariadb -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -d $DB
-script: "mix test --cover"
+script: "MYSQL_5_7=$MYSQL_5_7 mix test --cover"

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -68,7 +68,9 @@ defmodule Mariaex.Messages do
             field_type_var_string: 0xfd,
             field_type_string: 0xfe],
           null:
-           [field_type_null: 0x06]
+           [field_type_null: 0x06],
+          json:
+           [field_type_json: 0xf5]
          ]
 
   def __type__(:decode, _type, nil), do: nil
@@ -229,32 +231,32 @@ defmodule Mariaex.Messages do
     do: {nil, rest}
 
   def decode_bin_rows(<< len :: size(24)-little-integer, seqnum :: size(8)-integer, body :: size(len)-binary, rest :: binary>>,
-                      fields, nullbin_size, rows) do
+                      fields, nullbin_size, rows, json_library) do
     case body do
       <<0 :: 8, nullbin::size(nullbin_size)-little-unit(8), values :: binary>> ->
-        row = Mariaex.RowParser.decode_bin_rows(values, fields, nullbin)
-        decode_bin_rows(rest, fields, nullbin_size, [row | rows])
+        row = Mariaex.RowParser.decode_bin_rows(values, fields, nullbin, json_library)
+        decode_bin_rows(rest, fields, nullbin_size, [row | rows], json_library)
       body ->
         msg = decode_msg(body, :bin_rows)
         {:ok, packet(size: len, seqnum: seqnum, msg: msg, body: body), rows, rest}
     end
   end
-  def decode_bin_rows(<<rest :: binary>>, _fields, _nullbin_size, rows) do
+  def decode_bin_rows(<<rest :: binary>>, _fields, _nullbin_size, rows, _json_library) do
     {:more, rows, rest}
   end
 
   def decode_text_rows(<< len :: size(24)-little-integer, seqnum :: size(8)-integer, body :: size(len)-binary, rest :: binary>>,
-                      fields, rows) do
+                      fields, rows, json_library) do
     case body do
       << 254 :: 8, _ :: binary >> = body when byte_size(body) < 9 ->
         msg = decode_msg(body, :text_rows)
         {:ok, packet(size: len, seqnum: seqnum, msg: msg, body: body), rows, rest}
       body ->
-        row = Mariaex.RowParser.decode_text_rows(body, fields)
-        decode_text_rows(rest, fields, [row | rows])
+        row = Mariaex.RowParser.decode_text_rows(body, fields, json_library)
+        decode_text_rows(rest, fields, [row | rows], json_library)
     end
   end
-  def decode_text_rows(<<rest :: binary>>, _fields, rows) do
+  def decode_text_rows(<<rest :: binary>>, _fields, rows, _json_library) do
     {:more, rows, rest}
   end
 

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -207,7 +207,7 @@ defmodule Mariaex.Protocol do
   defp handle_handshake(packet(msg: ok_resp(affected_rows: _affected_rows, last_insert_id: _last_insert_id) = _packet), nil, state) do
     statement = "SET CHARACTER SET " <> (state.opts[:charset] || "utf8")
     query = %Query{type: :text, statement: statement}
-    case send_text_query(state, statement) |> text_query_recv(query) do
+    case send_text_query(state, statement) |> text_query_recv(query, []) do
       {:error, error, _} ->
         {:error, error}
       {:ok, _, state} ->

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -20,8 +20,8 @@ defmodule Mariaex.RowParser do
     {fields, div(length(fields) + 7 + 2, 8)}
   end
 
-  def decode_bin_rows(row, fields, nullint) do
-    decode_bin_rows(row, fields, nullint >>> 2, [])
+  def decode_bin_rows(row, fields, nullint, json_library) do
+    decode_bin_rows(row, fields, nullint >>> 2, [], json_library)
   end
 
   ## Helpers
@@ -66,6 +66,10 @@ defmodule Mariaex.RowParser do
     :int64
   end
 
+  defp type_to_atom({:json, :field_type_json}, _) do
+    :json
+  end
+
   defp type_to_atom({:string, _mysql_type}, _),              do: :string
   defp type_to_atom({:integer, :field_type_year}, _),        do: :uint16
   defp type_to_atom({:time, :field_type_time}, _),           do: :time
@@ -78,197 +82,221 @@ defmodule Mariaex.RowParser do
   defp type_to_atom({:bit, :field_type_bit}, _),             do: :bit
   defp type_to_atom({:null, :field_type_null}, _),           do: nil
 
-  defp decode_bin_rows(<<rest::bits>>, [_ | fields], nullint, acc) when (nullint &&& 1) === 1 do
-    decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc])
+  defp decode_bin_rows(<<rest::bits>>, [_ | fields], nullint, acc, json_library) when (nullint &&& 1) === 1 do
+    decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc], json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:string | fields], null_bitfield,  acc) do
-    decode_string(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:string | fields], null_bitfield,  acc, json_library) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint8 | fields], null_bitfield, acc) do
-    decode_uint8(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint8 | fields], null_bitfield, acc, json_library) do
+    decode_uint8(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int8 | fields], null_bitfield, acc) do
-    decode_int8(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int8 | fields], null_bitfield, acc, json_library) do
+    decode_int8(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint16 | fields], null_bitfield, acc) do
-    decode_uint16(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint16 | fields], null_bitfield, acc, json_library) do
+    decode_uint16(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int16 | fields], null_bitfield, acc) do
-    decode_int16(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int16 | fields], null_bitfield, acc, json_library) do
+    decode_int16(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint32 | fields], null_bitfield, acc) do
-    decode_uint32(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint32 | fields], null_bitfield, acc, json_library) do
+    decode_uint32(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int32 | fields], null_bitfield, acc) do
-    decode_int32(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int32 | fields], null_bitfield, acc, json_library) do
+    decode_int32(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint64 | fields], null_bitfield, acc) do
-    decode_uint64(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint64 | fields], null_bitfield, acc, json_library) do
+    decode_uint64(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int64 | fields], null_bitfield, acc) do
-    decode_int64(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int64 | fields], null_bitfield, acc, json_library) do
+    decode_int64(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:time | fields], null_bitfield, acc) do
-    decode_time(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:time | fields], null_bitfield, acc, json_library) do
+    decode_time(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:date | fields], null_bitfield, acc) do
-    decode_date(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:date | fields], null_bitfield, acc, json_library) do
+    decode_date(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:datetime | fields], null_bitfield, acc) do
-    decode_datetime(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:datetime | fields], null_bitfield, acc, json_library) do
+    decode_datetime(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:decimal | fields], null_bitfield, acc) do
-    decode_decimal(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:decimal | fields], null_bitfield, acc, json_library) do
+    decode_decimal(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:float32 | fields], null_bitfield, acc) do
-    decode_float32(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:float32 | fields], null_bitfield, acc, json_library) do
+    decode_float32(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:float64 | fields], null_bitfield, acc) do
-    decode_float64(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:float64 | fields], null_bitfield, acc, json_library) do
+    decode_float64(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:bit | fields], null_bitfield, acc) do
-    decode_string(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:bit | fields], null_bitfield, acc, json_library) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:nil | fields], null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc])
+  defp decode_bin_rows(<<rest::bits>>, [:json | fields], null_bitfield, acc, json_library) do
+    decode_json(rest, fields, null_bitfield >>> 1, acc, json_library)
   end
 
-  defp decode_bin_rows(<<>>, [], _, acc) do
+  defp decode_bin_rows(<<rest::bits>>, [:nil | fields], null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc], json_library)
+  end
+
+  defp decode_bin_rows(<<>>, [], _, acc, _) do
     Enum.reverse(acc)
   end
 
-  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) when len <= 250 do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_json(<< len::8, string::size(len)-binary, rest::bits >>, fields, nullint, acc, json_library) when len <= 250 do
+    json = json_library.decode!(string)
+    decode_bin_rows(rest, fields, nullint,  [json | acc], json_library)
   end
 
-  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_json(<< 252::8, len::16-little, string::size(len)-binary, rest::bits >>, fields, nullint, acc, json_library) do
+    json = json_library.decode!(string)
+    decode_bin_rows(rest, fields, nullint,  [json | acc], json_library)
   end
 
-  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_json(<< 253::8, len::24-little, string::size(len)-binary, rest::bits >>, fields, nullint, acc, json_library) do
+    json = json_library.decode!(string)
+    decode_bin_rows(rest, fields, nullint,  [json | acc], json_library)
   end
 
-  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>,  fields, nullint,  acc) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_json(<< 254::8, len::64-little, string::size(len)-binary, rest::bits >>, fields, nullint, acc, json_library) do
+    json = json_library.decode!(string)
+    decode_bin_rows(rest, fields, nullint,  [json | acc], json_library)
   end
 
-  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, json_library) when len <= 250 do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], json_library)
   end
 
-  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, json_library) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], json_library)
+  end
+
+  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, json_library) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], json_library)
+  end
+
+  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>,  fields, nullint,  acc, json_library) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], json_library)
+  end
+
+  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], json_library)
+  end
+
+  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], json_library)
   end
 
   defp decode_uint8(<<value::size(8)-little-unsigned, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_int8(<<value::size(8)-little-signed, rest::bits>>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                   fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_uint16(<<value::size(16)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                     fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_int16(<<value::size(16)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_uint32(<<value::size(32)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                     fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_int32(<<value::size(32)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_uint64(<<value::size(64)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                     fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_int64(<<value::size(64)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], json_library)
   end
 
   defp decode_decimal(<<length,  raw_value::size(length)-little-binary, rest::bits>>,
-                      fields, null_bitfield, acc) do
+                      fields, null_bitfield, acc, json_library) do
     value = Decimal.new(raw_value)
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], json_library)
   end
 
   defp decode_time(<< 0::8-little, rest::bits>>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc])
+                   fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc], json_library)
   end
 
   defp decode_time(<<8::8-little, _::8-little, _::32-little, hour::8-little, min::8-little, sec::8-little, rest::bits>>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc])
+                   fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc], json_library)
   end
 
   defp decode_time(<< 12::8, _::32-little, _::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                   fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc, json_library) do
 
-    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc])
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc], json_library)
   end
 
   defp decode_date(<< 0::8-little, rest::bits >>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc])
+                   fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc], json_library)
   end
 
   defp decode_date(<< 4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                   fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc, json_library) do
 
-    decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc])
+    decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc], json_library)
   end
 
   defp decode_datetime(<< 0::8-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc])
+                       fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc], json_library)
   end
 
   defp decode_datetime(<<4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc])
+                       fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc], json_library)
   end
 
   defp decode_datetime(<< 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc])
+                       fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc], json_library)
   end
 
   defp decode_datetime(<<11::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc])
+                       fields, null_bitfield, acc, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc], json_library)
   end
 
   ### TEXT ROW PARSER
@@ -280,76 +308,85 @@ defmodule Mariaex.RowParser do
     end
   end
 
-  def decode_text_rows(binary, fields) do
-    decode_text_part(binary, fields, [])
+  def decode_text_rows(binary, fields, json_library) do
+    decode_text_part(binary, fields, [], json_library)
   end
 
   ### IMPLEMENTATION
 
-  defp decode_text_part(<<len::8, string::size(len)-binary, rest::bits>>, fields, acc) when len <= 250 do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<len::8, string::size(len)-binary, rest::bits>>, fields, acc, json_library) when len <= 250 do
+    decode_text_rows(string, rest, fields, acc, json_library)
   end
 
-  defp decode_text_part(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, acc) do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, acc, json_library) do
+    decode_text_rows(string, rest, fields, acc, json_library)
   end
 
-  defp decode_text_part(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, acc) do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, acc, json_library) do
+    decode_text_rows(string, rest, fields, acc, json_library)
   end
 
-  defp decode_text_part(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>, fields, acc) do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>, fields, acc, json_library) do
+    decode_text_rows(string, rest, fields, acc, json_library)
   end
 
-  defp decode_text_part(<<>>, [], acc) do
+  defp decode_text_part(<<>>, [], acc, _json_library) do
     Enum.reverse(acc)
   end
 
-  defp decode_text_rows(string, rest, [:string | fields], acc) do
-    decode_text_part(rest, fields, [string | acc])
+  defp decode_text_rows(string, rest, [:string | fields], acc, json_library) do
+    decode_text_part(rest, fields, [string | acc], json_library)
   end
 
-  defp decode_text_rows(string, rest, [type | fields], acc)
+  defp decode_text_rows(string, rest, [type | fields], acc, json_library)
    when type in [:uint8, :int8, :uint16, :int16, :uint32, :int32, :uint64, :int64] do
-    decode_text_part(rest, fields, [:erlang.binary_to_integer(string) | acc])
+    decode_text_part(rest, fields, [:erlang.binary_to_integer(string) | acc], json_library)
   end
 
-  defp decode_text_rows(string, rest, [type | fields], acc)
+  defp decode_text_rows(string, rest, [type | fields], acc, json_library)
    when type in [:float32, :float64, :decimal] do
-    decode_text_part(rest, fields, [:erlang.binary_to_float(string) | acc])
+    decode_text_part(rest, fields, [:erlang.binary_to_float(string) | acc], json_library)
   end
 
-  defp decode_text_rows(string, rest, [:bit | fields], acc) do
-    decode_text_part(rest, fields, [string | acc])
+  defp decode_text_rows(string, rest, [:bit | fields], acc, json_library) do
+    decode_text_part(rest, fields, [string | acc], json_library)
   end
 
-  defp decode_text_rows(string, rest, [:time | fields], acc) do
-    decode_text_time(string, rest, fields, acc)
+  defp decode_text_rows(string, rest, [:time | fields], acc, json_library) do
+    decode_text_time(string, rest, fields, acc, json_library)
   end
 
-  defp decode_text_rows(string, rest, [:date | fields], acc) do
-    decode_text_date(string, rest, fields, acc)
+  defp decode_text_rows(string, rest, [:date | fields], acc, json_library) do
+    decode_text_date(string, rest, fields, acc, json_library)
   end
 
-  defp decode_text_rows(string, rest, [:datetime | fields], acc) do
-    decode_text_datetime(string, rest, fields, acc)
+  defp decode_text_rows(string, rest, [:datetime | fields], acc, json_library) do
+    decode_text_datetime(string, rest, fields, acc, json_library)
+  end
+
+  defp decode_text_rows(string, rest, [:json | fields], acc, json_library) do
+    decode_text_json(string, rest, fields, acc, json_library)
   end
 
   defmacrop to_int(value) do
     quote do: :erlang.binary_to_integer(unquote(value))
   end
 
-  defp decode_text_date(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>, rest, fields, acc) do
-    decode_text_part(rest, fields, [{to_int(year), to_int(month), to_int(day)} | acc])
+  defp decode_text_date(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>, rest, fields, acc, json_library) do
+    decode_text_part(rest, fields, [{to_int(year), to_int(month), to_int(day)} | acc], json_library)
   end
 
-  defp decode_text_time(<<hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc) do
-    decode_text_part(rest, fields, [{to_int(hour), to_int(min), to_int(sec), 0} | acc])
+  defp decode_text_time(<<hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc, json_library) do
+    decode_text_part(rest, fields, [{to_int(hour), to_int(min), to_int(sec), 0} | acc], json_library)
   end
 
   defp decode_text_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes,
-    _::8-little, hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc) do
-    decode_text_part(rest, fields, [{{to_int(year), to_int(month), to_int(day)}, {to_int(hour), to_int(min), to_int(sec), 0}} | acc])
+    _::8-little, hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc, json_library) do
+    decode_text_part(rest, fields, [{{to_int(year), to_int(month), to_int(day)}, {to_int(hour), to_int(min), to_int(sec), 0}} | acc], json_library)
+  end
+
+  defp decode_text_json(string, rest, fields, acc, json_library) do
+    json = json_library.decode!(string)
+    decode_text_part(rest, fields, [json | acc], json_library)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule Mariaex.Mixfile do
     [{:decimal, "~> 1.0"},
      {:db_connection, "~> 1.1"},
      {:coverex, "~> 1.4.10", only: :test},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+     {:ex_doc, ">= 0.0.0", only: :dev},
+     {:poison, "~> 2.1", optional: true}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -5,11 +5,11 @@
   "decimal": {:hex, :decimal, "1.1.0", "3333732f17a90ff3057d7ab8c65f0930ca2d67e15cca812a91ead5633ed472fe", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:rebar3, :mix], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.10.0", "4727b3a5e57e9a4ff168a3c2883e20f1208103a41bccc4754f15a9366f49b676", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []}}

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -293,7 +293,10 @@ defmodule QueryTest do
     timestamp_with_msec = {date, {13, 32, 15, 12}}
     table = "test_timestamps"
 
-    sql = "CREATE TABLE #{table} (id int, ts1 timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, ts2 timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP);"
+    # MySQL 5.7 requests explicit defaults for timestamp.
+    # ref. https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp
+    # There can be only one timestamp column with CURRENT_TIMESTAMP in default, so ts2 default value set to 2000-01-01 00:00:00
+    sql = "CREATE TABLE #{table} (id int, ts1 timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, ts2 timestamp NOT NULL DEFAULT '2000-01-01 00:00:00');"
     :ok = query(sql, [])
 
     insert = ~s{INSERT INTO #{table} (id, ts1, ts2) VALUES (?, ?, ?)}

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -244,7 +244,7 @@ defmodule QueryTest do
     assert query("SELECT d FROM #{table} WHERE id = ?", [1]) == [[date0]]
 
     # MySQL 5.7 prohibits zero dates on strict mode
-    unless System.get_env "MYSQL_5_7" do
+    unless System.get_env("MYSQL_5_7") === "true" do
       :ok = query(insert, [2, date1])
       assert query("SELECT d FROM #{table} WHERE id = ?", [2]) == [[date1]]
     end
@@ -310,7 +310,7 @@ defmodule QueryTest do
     assert query("SELECT ts1, ts2 FROM #{table} WHERE id = ?", [1]) == [[timestamp, {date, {13, 32, 15, 0}}]]
 
     # MySQL 5.7 prohibits zero dates on strict mode
-    unless System.get_env "MYSQL_5_7" do
+    unless System.get_env("MYSQL_5_7") === "true" do
       assert query("SELECT timestamp('0000-00-00 00:00:00')", []) == [[{{0, 0, 0}, {0, 0, 0, 0}}]]
     end
 
@@ -601,7 +601,7 @@ defmodule QueryTest do
     assert :ok = query("REPLACE INTO test_replace VALUES (1, 'New', ?);", [timestamp])
   end
 
-  if System.get_env "MYSQL_5_7" do
+  if System.get_env("MYSQL_5_7") === "true "do
     test "support json for MySQL > 5.7.9", context do
       opts = [json_library: Poison]
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -32,12 +32,11 @@ sql = """
 """
 
 cmds = [
-    ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
-    ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci'";),
-    ~s(mysql #{mysql_connect} -e "DROP USER 'mariaex_user'@'%';"),
-    ~s(mysql #{mysql_connect} -e "CREATE USER 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass';"),
-    ~s(mysql #{mysql_connect} -e "GRANT ALL PRIVILEGES ON *.* TO 'mariaex_user'@'%' WITH GRANT OPTION;"),
-    ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=#{mysql_protocol} -u mariaex_user -pmariaex_pass mariaex_test -e "#{sql}")
+  ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
+  ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci'";),
+  ~s(mysql #{mysql_connect} -e "CREATE USER 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass';"),
+  ~s(mysql #{mysql_connect} -e "GRANT ALL PRIVILEGES ON *.* TO 'mariaex_user'@'%' WITH GRANT OPTION;"),
+  ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=#{mysql_protocol} -u mariaex_user -pmariaex_pass mariaex_test -e "#{sql}")
 ]
 
 Enum.each(cmds, fn cmd ->

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -21,7 +21,8 @@ end
 
 mysql_port = System.get_env("MDBPORT") || 3306
 mysql_host = System.get_env("MDBHOST") || "localhost"
-mysql_connect = "-u root #{mysql_pass_switch} --host=#{mysql_host} --port=#{mysql_port} --protocol=tcp"
+mysql_protocol = System.get_env("MDBPROTOCOL") || "tcp"
+mysql_connect = "-u root #{mysql_pass_switch} --host=#{mysql_host} --port=#{mysql_port} --protocol=#{mysql_protocol}"
 
 sql = """
   CREATE TABLE test1 (id serial, title text);
@@ -30,13 +31,25 @@ sql = """
   DROP TABLE test1;
 """
 
-cmds = [
-  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'localhost' IDENTIFIED BY 'mariaex_pass';"),
-  ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
-  ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci'";),
-  ~s(mysql #{mysql_connect} mariaex_test -e "#{sql}"),
-  ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=tcp -u mariaex_user -pmariaex_pass mariaex_test -e "#{sql}")
-]
+cmds = if System.get_env("MYSQL_5_7") do
+  [
+    ~s(mysql #{mysql_connect} -e "DROP USER 'mariaex_user'@'localhost';"),
+    ~s(mysql #{mysql_connect} -e "CREATE USER 'mariaex_user'@'localhost' IDENTIFIED BY 'mariaex_pass';"),
+    ~s(mysql #{mysql_connect} -e "GRANT ALL PRIVILEGES ON *.* TO 'mariaex_user'@'localhost' WITH GRANT OPTION;"),
+    ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
+    ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci'";),
+    ~s(mysql #{mysql_connect} mariaex_test -e "#{sql}"),
+    ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=#{mysql_protocol} -u mariaex_user -pmariaex_pass mariaex_test -e "#{sql}")
+  ]
+else
+  [
+    ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'localhost' IDENTIFIED BY 'mariaex_pass';"),
+    ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
+    ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci'";),
+    ~s(mysql #{mysql_connect} mariaex_test -e "#{sql}"),
+    ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=#{mysql_protocol} -u mariaex_user -pmariaex_pass mariaex_test -e "#{sql}")
+  ]
+end
 
 Enum.each(cmds, fn cmd ->
   {status, output} = run_cmd.(cmd)

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -28,7 +28,7 @@ defmodule TextQueryTest do
     """
     {:ok, _} = Mariaex.query(pid, insert, [], [query_type: :text])
 
-    if System.get_env "MYSQL_5_7" do
+    if System.get_env("MYSQL_5_7") === "true" do
       create = """
       CREATE TABLE test_text_json_query_table (
       id serial,
@@ -90,7 +90,7 @@ defmodule TextQueryTest do
     assert(rows == [[1, "hello"], [2, "goodbye"]])
   end
 
-  if System.get_env "MYSQL_5_7" do
+  if System.get_env("MYSQL_5_7") === "true" do
     test "select json", context do
       opts = [json_library: Poison]
 

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -27,6 +27,25 @@ defmodule TextQueryTest do
     (2, false, b'11', 'goodbye', 'earth', 1.2, '2016-09-26T16:36:07', '0001-01-01 00:00:01')
     """
     {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: insert}, [])
+
+    if System.get_env "MYSQL_5_7" do
+      create = """
+      CREATE TABLE test_text_json_query_table (
+      id serial,
+      map json,
+      dt datetime
+      )
+      """
+      {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: create}, [])
+      insert = """
+      INSERT INTO test_text_json_query_table (id, map, dt)
+      VALUES
+      (1, '{"hoge": "1", "huga": "2"}', '2017-01-01 00:00:00'),
+      (2, '{"hoge": "3", "huga": "4"}', '2017-01-01 00:00:01')
+      """
+      {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: insert}, [])
+    end
+
     {:ok, [pid: pid]}
   end
 
@@ -69,5 +88,14 @@ defmodule TextQueryTest do
   test "select multiple columns", context do
     rows = execute_text("SELECT id, varchars FROM test_text_query_table", [])
     assert(rows == [[1, "hello"], [2, "goodbye"]])
+  end
+
+  if System.get_env "MYSQL_5_7" do
+    test "select json", context do
+      opts = [json_library: Poison]
+
+      rows = execute_text("SELECT map FROM test_text_json_query_table", [], opts)
+      assert(rows == [[%{"hoge" => "1", "huga" => "2"}], [%{"hoge" => "3", "huga" => "4"}]])
+    end
   end
 end


### PR DESCRIPTION
fixes #119 .

I cherry-picked commit of 86e2d1ca96419ea5e3774b66ab71b108d819e4a7 , and apply its commit onto current code ( `v0.8.2` ).

Encode and decode library for json can choose by `opts[:json_library]` (Default set to `Poison`).

#### Usage from Ecto

```elixir
method = some_method # :all, :insert, :update, ... etc

# in Mariaex, json_library will set to Poison
Kernel.apply(Some.Repo, method, [%Some.Queryable{}]

# in Mariaex, json_library will set to SomeLibrary
Kernel.apply(Some.Repo, method, [%Some.Queryable{}, [json_library: SomeLibrary]]
```

I am very new to elixir and mariaex, so if there is some strange changeset, feel free to notice me.