### PR TITLE
do disconnect on handshake error

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -154,7 +154,11 @@ defmodule Mariaex.Protocol do
   defp handshake_recv(state, request) do
     case msg_recv(state) do
       {:ok, packet, state} ->
-        handle_handshake(packet, request, state)
+        case handle_handshake(packet, request, state) do
+          {:error, error} ->
+            do_disconnect(state, error, "") |> connected()
+          other -> other
+        end
       {:error, reason} ->
         {sock_mod, _} = state.sock
         Mariaex.Protocol.do_disconnect(state, {sock_mod.tag, "recv", reason, ""}) |> connected()


### PR DESCRIPTION
Socket is not closed when authentication is failed.
This will cause the system running out of file descriptors.
