### PR TITLE
fix close socket when disconnect failed

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -256,7 +256,7 @@ defmodule Mariaex.Protocol do
       {:ok, packet(msg: _), _state} ->
         sock_mod.close(sock)
       {:error, _} ->
-        :ok
+        sock_mod.close(sock)
     end
     _ = sock_mod.recv_active(sock, 0, "")
     :ok


### PR DESCRIPTION

```
Mariaex.start_link(hostname: "127.0.0.1", port: 6379)
```
Port will never close till runing out of local port in this situation.
I think #178 should be considerd, it will cause the same problem when you authenticate failed.