### PR TITLE
Introduce :query_type prepare option

### DIFF
--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -111,8 +111,7 @@ defmodule Mariaex do
     * `:binary_as` - encoding binary as `:field_type_var_string` (default)
        or `:field_type_blob`
     * `:query_type` - `:binary` to use binary protocol, `:text` to use text
-      protocol and `:unknown` to try binary but fallback to text (default
-      `:unknown`)
+      protocol  `nil` to try binary but fallback to text (default `nil`)
 
   ## Examples
 
@@ -132,12 +131,12 @@ defmodule Mariaex do
   def query(conn, statement, params \\ [], opts \\ [])
 
   def query(conn, statement, params, opts) do
-    case Keyword.get(opts, :query_type, :unknown) do
+    case Keyword.get(opts, :query_type) do
       :text ->
         query = %Query{type: :text, statement: statement, ref: make_ref(),
                        num_params: 0}
         execute(conn, query, [], opts)
-      type when type in [:binary, :unknown] ->
+      type when type in [:binary, nil] ->
         query = %Query{type: type, statement: statement}
         prepare_execute(conn, query, params, defaults(opts))
     end
@@ -172,8 +171,7 @@ defmodule Mariaex do
     * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
     * `:query_type` - `:binary` to use binary protocol, `:text` to use text
-      protocol and `:unknown` to try binary but fallback to text (default
-      `:unknown`)
+      protocol or `nil` to try binary but fallback to text (default `nil`)
 
   ## Examples
 
@@ -181,12 +179,12 @@ defmodule Mariaex do
   """
   @spec prepare(conn, iodata, iodata, Keyword.t) :: {:ok, Mariaex.Query.t} | {:error, Mariaex.Error.t}
   def prepare(conn, name, statement, opts \\ []) do
-    case Keyword.get(opts, :query_type, :unknown) do
+    case Keyword.get(opts, :query_type) do
       :text ->
         query = %Query{type: :text, name: name, statement: statement,
                        ref: make_ref(), num_params: 0}
         {:ok, query}
-      type when type in [:binary, :unknown] ->
+      type when type in [:binary, nil] ->
         query = %Query{type: type, name: name, statement: statement}
         prepare_binary(conn, query, opts)
     end
@@ -378,8 +376,7 @@ defmodule Mariaex do
   ### Options
     * `:max_rows` - Maximum numbers of rows in a result (default to `#{@max_rows}`)
     * `:query_type` - `:binary` to use binary protocol, `:text` to use text
-      protocol and `:unknown` to try binary but fallback to text (default
-      `:unknown`)
+      protocol or `nil` to try binary but fallback to text (default `nil`)
 
       Mariaex.transaction(pid, fn(conn) ->
         stream = Mariaex.stream(conn, "SELECT id FROM posts WHERE title like $1", ["%my%"])
@@ -394,12 +391,12 @@ defmodule Mariaex do
     DBConnection.stream(conn, query, params, defaults(opts))
   end
   def stream(conn, statement, params, opts) do
-    case Keyword.get(opts, :query_type, :unknown) do
+    case Keyword.get(opts, :query_type) do
       :text ->
         query = %Query{type: :text, statement: statement, ref: make_ref(),
                        num_params: 0}
         stream(conn, query, [], opts)
-      type when type in [:binary, :unknown] ->
+      type when type in [:binary, nil] ->
         query = %Query{type: type, statement: statement}
         prepare_stream(conn, query, params, opts)
     end

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -314,15 +314,16 @@ defmodule Mariaex.Protocol do
   def handle_prepare(%Query{name: @reserved_prefix <> _} = query, _, s) do
     reserved_error(query, s)
   end
-  def handle_prepare(%Query{type: nil, statement: statement} = query, opts, s) do
-    command = get_command(statement)
-    handle_prepare(%{query | type: request_type(command), binary_as: s.binary_as}, opts, s)
-  end
-  def handle_prepare(%Query{type: :text} = query, _, s) do
-    {:ok, %Query{query | ref: make_ref(), num_params: 0}, s}
+  def handle_prepare(%Query{type: :unknown} = query, opts, s) do
+    case handle_prepare(%Query{query | type: :binary}, opts, s) do
+      {:error,  %Mariaex.Error{mariadb: %{code: 1295}}, s} ->
+        {:ok, %Query{query | type: :text, ref: make_ref(), num_params: 0}, s}
+      other ->
+        other
+    end
   end
   def handle_prepare(%Query{type: :binary} = query, _, s) do
-    case prepare_lookup(query, s) do
+    case prepare_lookup(%Query{query | binary_as: s.binary_as}, s) do
       {:prepared, query} ->
         {:ok, query, s}
       {:prepare, query} ->
@@ -331,13 +332,9 @@ defmodule Mariaex.Protocol do
         close_prepare(id, query, s)
     end
   end
-
-  defp request_type(command) do
-    if command in [:insert, :select, :update, :delete, :replace, :show, :call, :describe] do
-      :binary
-    else
-      :text
-    end
+  def handle_prepare(%Query{type: _} = query, _, s) do
+    error = ArgumentError.exception("query #{inspect query} is already prepared")
+    {:error, error, s}
   end
 
   defp prepare_lookup(%Query{name: "", statement: statement} = query, %{lru_cache: cache}) do
@@ -445,9 +442,6 @@ defmodule Mariaex.Protocol do
       {:close_prepare_execute, id, query} ->
         prepare_execute(&close_prepare(id, query, &1), params, state)
     end
-  end
-  def handle_execute(query, params, _opts, state) do
-    query_error(state, "unsupported parameterized query #{inspect(query.statement)} parameters #{inspect(params)}")
   end
 
   defp execute_lookup(%Query{name: ""} = query, %{lru_cache: cache}) do
@@ -1136,10 +1130,6 @@ defmodule Mariaex.Protocol do
     %{s | state: :column_count}
   end
 
-  defp query_error(s, msg) do
-    {:error, ArgumentError.exception(msg), s}
-  end
-
   defp abort_statement(s, query, code, message) do
     abort_statement(s, query, %Mariaex.Error{mariadb: %{code: code, message: message}})
   end
@@ -1157,14 +1147,6 @@ defmodule Mariaex.Protocol do
     error = ArgumentError.exception("query #{inspect query} uses reserved name")
     {:error, error, s}
   end
-
-  @doc """
-  Get command from statement
-  """
-  def get_command(statement) when is_binary(statement) do
-    statement |> :binary.split([" ", "\n"]) |> hd |> String.downcase |> String.to_atom
-  end
-  def get_command(nil), do: nil
 
   def get_3_digits_version(string) do
     [major, minor, rest] = String.split(string, ".", parts: 3)

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -314,7 +314,7 @@ defmodule Mariaex.Protocol do
   def handle_prepare(%Query{name: @reserved_prefix <> _} = query, _, s) do
     reserved_error(query, s)
   end
-  def handle_prepare(%Query{type: :unknown} = query, opts, s) do
+  def handle_prepare(%Query{type: nil} = query, opts, s) do
     case handle_prepare(%Query{query | type: :binary}, opts, s) do
       {:error,  %Mariaex.Error{mariadb: %{code: 1295}}, s} ->
         {:ok, %Query{query | type: :text, ref: make_ref(), num_params: 0}, s}

--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -50,18 +50,18 @@ defimpl DBConnection.Query, for: Mariaex.Query do
 
   This function is called to encode a query before it is executed.
   """
-  def encode(%Mariaex.Query{ref: nil, type: :binary} = query, _params, _opts) do
+  def encode(%Mariaex.Query{type: nil} = query, _params, _opts) do
     raise ArgumentError, "query #{inspect query} has not been prepared"
   end
-  def encode(%Mariaex.Query{type: :binary, num_params: num_params} = query, params, _opts)
+  def encode(%Mariaex.Query{num_params: num_params} = query, params, _opts)
       when length(params) != num_params do
     raise ArgumentError, "parameters must be of length #{num_params} for query #{inspect query}"
   end
   def encode(%Mariaex.Query{type: :binary, binary_as: binary_as}, params, _opts) do
     parameters_to_binary(params, binary_as)
   end
-  def encode(%Mariaex.Query{type: :text}, params, _opts) do
-    params
+  def encode(%Mariaex.Query{type: :text}, [], _opts) do
+    []
   end
 
   defp parameters_to_binary([], _binary_as), do: <<>>
@@ -126,28 +126,15 @@ defimpl DBConnection.Query, for: Mariaex.Query do
   defp encode_param(other, _binary_as),
     do: raise ArgumentError, "query has invalid parameter #{inspect other}"
 
-  @commands_without_rows [:create, :insert, :replace, :update, :delete, :set,
-                          :alter, :rename, :drop, :begin, :commit, :rollback,
-                          :savepoint, :execute, :prepare, :truncate, :grant]
-
-  def decode(%Mariaex.Query{statement: statement}, {res, nil}, _) do
-    command = Mariaex.Protocol.get_command(statement)
-    %Mariaex.Result{res | command: command, rows: nil}
+  def decode(_, {res, nil}, _) do
+    %Mariaex.Result{res | rows: nil}
   end
-  def decode(%Mariaex.Query{statement: statement}, {res, columns}, opts) do
-    command = Mariaex.Protocol.get_command(statement)
-    if command in @commands_without_rows do
-      %Mariaex.Result{res | command: command, rows: nil}
-    else
-      %Mariaex.Result{rows: rows} = res
-      decoded = do_decode(rows, opts)
-      include_table_name = opts[:include_table_name]
-      columns = for %Column{} = column <- columns, do: column_name(column, include_table_name)
-      %Mariaex.Result{res | command: command,
-                            rows: decoded,
-                            columns: columns,
-                            num_rows: length(decoded)}
-    end
+  def decode(_, {res, columns}, opts) do
+    %Mariaex.Result{rows: rows} = res
+    decoded = do_decode(rows, opts)
+    include_table_name = opts[:include_table_name]
+    columns = for %Column{} = column <- columns, do: column_name(column, include_table_name)
+    %Mariaex.Result{res | rows: decoded, columns: columns, num_rows: length(decoded)}
   end
 
   ## helpers

--- a/lib/mariaex/structs.ex
+++ b/lib/mariaex/structs.ex
@@ -11,14 +11,13 @@ defmodule Mariaex.Result do
   """
 
   @type t :: %__MODULE__{
-    command:  atom,
     columns:  [String.t] | nil,
     rows:     [tuple] | nil,
     last_insert_id: integer,
     num_rows: integer,
     connection_id: nil}
 
-  defstruct [:command, :columns, :rows, :last_insert_id, :num_rows, :connection_id]
+  defstruct [:columns, :rows, :last_insert_id, :num_rows, :connection_id]
 end
 
 defmodule Mariaex.Error do

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -16,7 +16,7 @@ defmodule PreparedQueryTest do
   test "executing unprepared query raises", context do
     :ok = query("CREATE TABLE unprepared_test (id int, text text)", [])
     conn = context[:pid]
-    query = %Mariaex.Query{type: :binary, name: "unprepared_test", statement: "SELECT * FROM unprepared_test"}
+    query = %Mariaex.Query{name: "unprepared_test", statement: "SELECT * FROM unprepared_test"}
     assert_raise ArgumentError, ~r"has not been prepared", fn() -> Mariaex.execute!(conn, query, []) end
   end
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -403,7 +403,6 @@ defmodule QueryTest do
     {:ok, res} = Mariaex.Connection.query(context[:pid], "SELECT 1 AS first, 10 AS last", [])
 
     assert %Mariaex.Result{} = res
-    assert res.command == :select
     assert res.columns == ["first", "last"]
     assert res.num_rows == 1
   end
@@ -454,12 +453,10 @@ defmodule QueryTest do
 
     {:ok, res} = Mariaex.Connection.query(context[:pid], "UPDATE #{table} SET num = 2", [])
     assert %Mariaex.Result{} = res
-    assert res.command == :update
     assert res.num_rows == 1
 
     {:ok, res} = Mariaex.Connection.query(context[:pid], "UPDATE #{table} SET num = 2", [])
     assert %Mariaex.Result{} = res
-    assert res.command == :update
     assert res.num_rows == 1
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -72,8 +72,8 @@ defmodule Mariaex.TestHelper do
 
   defmacro execute_text(stat, params, opts \\ []) do
     quote do
-      case Mariaex.execute(var!(context)[:pid], %Mariaex.Query{type: :text, statement: unquote(stat)},
-            unquote(params), unquote(opts)) do
+      case Mariaex.query(var!(context)[:pid], unquote(stat),
+            unquote(params), [query_type: :text] ++ unquote(opts)) do
         {:ok, %Mariaex.Result{rows: nil}} -> :ok
         {:ok, %Mariaex.Result{rows: rows}} -> rows
         {:error, %Mariaex.Error{} = err} -> err

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -19,14 +19,14 @@ defmodule TextQueryTest do
     dt datetime
     )
     """
-    {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: create}, [])
+    {:ok, _} = Mariaex.query(pid, create, [], [query_type: :text])
     insert = """
     INSERT INTO test_text_query_table (id, bools, bits, varchars, texts, floats, ts, dt)
     VALUES
     (1, true, b'10', 'hello', 'world', 1.1, '2016-09-26 16:36:06', '0001-01-01 00:00:00'),
     (2, false, b'11', 'goodbye', 'earth', 1.2, '2016-09-26T16:36:07', '0001-01-01 00:00:01')
     """
-    {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: insert}, [])
+    {:ok, _} = Mariaex.query(pid, insert, [], [query_type: :text])
     {:ok, [pid: pid]}
   end
 


### PR DESCRIPTION
Closes #174.

Parsing the SQL is unreliable way to get the command. Instead require `query_type: :text to use text protocol. If `query_type: :unknown` or not set, then try binary and fallback to text. Force binary with `query_type: :text`. More SQL statements should than before but text queries without the option will be slower. Note that this should not hurt Ecto performance (unless doing raw queries) as it will always be able to use binary protocol for DSL or transaction.