### PR TITLE
Add tagged parameters to encode.

### DIFF
--- a/lib/mariaex/query.ex
+++ b/lib/mariaex/query.ex
@@ -97,6 +97,10 @@ defimpl DBConnection.Query, for: Mariaex.Query do
 
   defp encode_param(nil, _binary_as),
     do: {1, :field_type_null, ""}
+  defp encode_param({:binary, bin}, _binary_as) when is_binary(bin),
+    do: encode_param(bin, :field_type_blob)
+  defp encode_param({:string, bin}, _binary_as) when is_binary(bin),
+    do: encode_param(bin, :field_type_var_string)
   defp encode_param(bin, binary_as) when is_binary(bin),
     do: {0, binary_as, << to_length_encoded_integer(byte_size(bin)) :: binary, bin :: binary >>}
   defp encode_param(int, _binary_as) when is_integer(int),

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -94,6 +94,22 @@ defmodule QueryTest do
     assert query("SELECT active, tiny from #{table} WHERE id = ?", [2]) == [[1, 0]]
   end
 
+  test "tagged binary and string tests", context do
+    table = "tagged_test"
+    binary = 15..0 |> Enum.into([]) |> IO.iodata_to_binary()
+    string = "☀☁☂☃☄★☆☇☈☉☊☋☌☍☎☏"
+
+    :ok = query("CREATE TABLE #{table} (id serial, bin binary(16), str varchar(16))", [])
+
+    :ok = query(~s{INSERT INTO #{table} (id, bin, str) VALUES (?, ?, ?)},
+                [1, {:binary, binary}, {:string, string}])
+
+    assert query("SELECT bin, str from #{table} WHERE id = ?", [1]) == [[binary, string]]
+
+    assert query("SELECT bin, str from #{table} WHERE id = ? AND bin = ? AND str = ?",
+                 [1, {:binary, binary}, {:string, string}]) == [[binary, string]]
+  end
+
   test "support numeric data types using prepared statements", context do
     integer = 16
     float   = 0.1


### PR DESCRIPTION
Tagged Elixir strings allow pushing BINARY and CHAR fields in a single query. They also can be used in Ecto adapters to leverage Ecto's knowledge of types.