### PR TITLE
Support Elixir v1.3 calendar types

### DIFF
--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -64,6 +64,8 @@ defmodule Mariaex do
      if not `DBConnection.Connection` (default: `DBConnection.Connection`);
     * `:name` - A name to register the started process (see the `:name` option
     in `GenServer.start_link/3`).
+    * `:datetime` - How datetimes should be returned. `:structs` for Elixir v1.3
+      calendar types or `:tuples` for the backwards compatible tuples
 
   ## Function signatures
 

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -20,8 +20,8 @@ defmodule Mariaex.RowParser do
     {fields, div(length(fields) + 7 + 2, 8)}
   end
 
-  def decode_bin_rows(row, fields, nullint) do
-    decode_bin_rows(row, fields, nullint >>> 2, [])
+  def decode_bin_rows(row, fields, nullint, datetime) do
+    decode_bin_rows(row, fields, nullint >>> 2, [], datetime)
   end
 
   ## Helpers
@@ -78,197 +78,252 @@ defmodule Mariaex.RowParser do
   defp type_to_atom({:bit, :field_type_bit}, _),             do: :bit
   defp type_to_atom({:null, :field_type_null}, _),           do: nil
 
-  defp decode_bin_rows(<<rest::bits>>, [_ | fields], nullint, acc) when (nullint &&& 1) === 1 do
-    decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc])
+  defp decode_bin_rows(<<rest::bits>>, [_ | fields], nullint, acc, datetime) when (nullint &&& 1) === 1 do
+    decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc], datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:string | fields], null_bitfield,  acc) do
-    decode_string(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:string | fields], null_bitfield,  acc, datetime) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint8 | fields], null_bitfield, acc) do
-    decode_uint8(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint8 | fields], null_bitfield, acc, datetime) do
+    decode_uint8(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int8 | fields], null_bitfield, acc) do
-    decode_int8(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int8 | fields], null_bitfield, acc, datetime) do
+    decode_int8(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint16 | fields], null_bitfield, acc) do
-    decode_uint16(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint16 | fields], null_bitfield, acc, datetime) do
+    decode_uint16(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int16 | fields], null_bitfield, acc) do
-    decode_int16(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int16 | fields], null_bitfield, acc, datetime) do
+    decode_int16(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint32 | fields], null_bitfield, acc) do
-    decode_uint32(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint32 | fields], null_bitfield, acc, datetime) do
+    decode_uint32(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int32 | fields], null_bitfield, acc) do
-    decode_int32(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int32 | fields], null_bitfield, acc, datetime) do
+    decode_int32(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint64 | fields], null_bitfield, acc) do
-    decode_uint64(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:uint64 | fields], null_bitfield, acc, datetime) do
+    decode_uint64(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int64 | fields], null_bitfield, acc) do
-    decode_int64(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:int64 | fields], null_bitfield, acc, datetime) do
+    decode_int64(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:time | fields], null_bitfield, acc) do
-    decode_time(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:time | fields], null_bitfield, acc, datetime) do
+    decode_time(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:date | fields], null_bitfield, acc) do
-    decode_date(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:date | fields], null_bitfield, acc, datetime) do
+    decode_date(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:datetime | fields], null_bitfield, acc) do
-    decode_datetime(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:datetime | fields], null_bitfield, acc, datetime) do
+    decode_datetime(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:decimal | fields], null_bitfield, acc) do
-    decode_decimal(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:decimal | fields], null_bitfield, acc, datetime) do
+    decode_decimal(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:float32 | fields], null_bitfield, acc) do
-    decode_float32(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:float32 | fields], null_bitfield, acc, datetime) do
+    decode_float32(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:float64 | fields], null_bitfield, acc) do
-    decode_float64(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:float64 | fields], null_bitfield, acc, datetime) do
+    decode_float64(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:bit | fields], null_bitfield, acc) do
-    decode_string(rest, fields, null_bitfield >>> 1, acc)
+  defp decode_bin_rows(<<rest::bits>>, [:bit | fields], null_bitfield, acc, datetime) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc, datetime)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:nil | fields], null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc])
+  defp decode_bin_rows(<<rest::bits>>, [:nil | fields], null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc], datetime)
   end
 
-  defp decode_bin_rows(<<>>, [], _, acc) do
+  defp decode_bin_rows(<<>>, [], _, acc, _datetime) do
     Enum.reverse(acc)
   end
 
-  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) when len <= 250 do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime) when len <= 250 do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
   end
 
-  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
   end
 
-  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
   end
 
-  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>,  fields, nullint,  acc) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc])
+  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>,  fields, nullint,  acc, datetime) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
   end
 
-  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime)
   end
 
-  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime)
   end
 
   defp decode_uint8(<<value::size(8)-little-unsigned, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_int8(<<value::size(8)-little-signed, rest::bits>>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                   fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_uint16(<<value::size(16)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                     fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_int16(<<value::size(16)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_uint32(<<value::size(32)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                     fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_int32(<<value::size(32)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_uint64(<<value::size(64)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                     fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_int64(<<value::size(64)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc])
+                    fields, null_bitfield, acc, datetime) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
   end
 
   defp decode_decimal(<<length,  raw_value::size(length)-little-binary, rest::bits>>,
-                      fields, null_bitfield, acc) do
+                      fields, null_bitfield, acc, datetime) do
     value = Decimal.new(raw_value)
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc])
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime)
   end
 
   defp decode_time(<< 0::8-little, rest::bits>>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc])
+                   fields, null_bitfield, acc, :structs) do
+    time = %Time{hour: 0, minute: 0, second: 0}
+    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs)
   end
 
   defp decode_time(<<8::8-little, _::8-little, _::32-little, hour::8-little, min::8-little, sec::8-little, rest::bits>>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc])
+                   fields, null_bitfield, acc, :structs) do
+    time = %Time{hour: hour, minute: min, second: sec}
+    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs)
   end
 
   defp decode_time(<< 12::8, _::32-little, _::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                   fields, null_bitfield, acc) do
+                   fields, null_bitfield, acc, :structs) do
+    time = %Time{hour: hour, minute: min, second: sec, microsecond: {msec, 6}}
+    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs)
+  end
 
-    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc])
+  defp decode_time(<< 0::8-little, rest::bits>>,
+                   fields, null_bitfield, acc, :tuples) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc], :tuples)
+  end
+
+  defp decode_time(<<8::8-little, _::8-little, _::32-little, hour::8-little, min::8-little, sec::8-little, rest::bits>>,
+                   fields, null_bitfield, acc, :tuples) do
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc], :tuples)
+  end
+
+  defp decode_time(<< 12::8, _::32-little, _::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
+                   fields, null_bitfield, acc, :tuples) do
+
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc], :tuples)
   end
 
   defp decode_date(<< 0::8-little, rest::bits >>,
-                   fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc])
+                   fields, null_bitfield, acc, :structs) do
+    date = %Date{year: 0, month: 1, day: 1}
+    decode_bin_rows(rest, fields, null_bitfield, [date | acc], :structs)
   end
 
   defp decode_date(<< 4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                   fields, null_bitfield, acc) do
-
-    decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc])
+                   fields, null_bitfield, acc, :structs) do
+    date = %Date{year: year, month: month, day: day}
+    decode_bin_rows(rest, fields, null_bitfield, [date | acc], :structs)
   end
 
+  defp decode_date(<< 0::8-little, rest::bits >>,
+                   fields, null_bitfield, acc, :tuples) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc], :tuples)
+  end
+
+  defp decode_date(<< 4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
+                   fields, null_bitfield, acc, :tuples) do
+
+    decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc], :tuples)
+  end
+
+
   defp decode_datetime(<< 0::8-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc])
+                       fields, null_bitfield, acc, :structs) do
+    datetime = %NaiveDateTime{year: 0, month: 1, day: 1, hour: 0, minute: 0, second: 0}
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
   end
 
   defp decode_datetime(<<4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc])
+                       fields, null_bitfield, acc, :structs) do
+    datetime = %NaiveDateTime{year: year, month: month, day: day, hour: 0, minute: 0, second: 0}
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
   end
 
   defp decode_datetime(<< 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc])
+                       fields, null_bitfield, acc, :structs) do
+    datetime = %NaiveDateTime{year: year, month: month, day: day, hour: hour, minute: min, second: sec}
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
   end
 
   defp decode_datetime(<<11::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                       fields, null_bitfield, acc) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc])
+                       fields, null_bitfield, acc, :structs) do
+    datetime = %NaiveDateTime{year: year, month: month, day: day, hour: hour, minute: min, second: sec, microsecond: {msec, 6}}
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
+  end
+
+  defp decode_datetime(<< 0::8-little, rest::bits >>,
+                       fields, null_bitfield, acc, :tuples) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc], :tuples)
+  end
+
+  defp decode_datetime(<<4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
+                       fields, null_bitfield, acc, :tuples) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc], :tuples)
+  end
+
+  defp decode_datetime(<< 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, rest::bits >>,
+                       fields, null_bitfield, acc, :tuples) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc], :tuples)
+  end
+
+  defp decode_datetime(<<11::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
+                       fields, null_bitfield, acc, :tuples) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc], :tuples)
   end
 
   ### TEXT ROW PARSER
@@ -280,76 +335,93 @@ defmodule Mariaex.RowParser do
     end
   end
 
-  def decode_text_rows(binary, fields) do
-    decode_text_part(binary, fields, [])
+  def decode_text_rows(binary, fields, datetime) do
+    decode_text_part(binary, fields, [],  datetime)
   end
 
   ### IMPLEMENTATION
 
-  defp decode_text_part(<<len::8, string::size(len)-binary, rest::bits>>, fields, acc) when len <= 250 do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<len::8, string::size(len)-binary, rest::bits>>, fields, acc, datetime) when len <= 250 do
+    decode_text_rows(string, rest, fields, acc, datetime)
   end
 
-  defp decode_text_part(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, acc) do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, acc, datetime) do
+    decode_text_rows(string, rest, fields, acc, datetime)
   end
 
-  defp decode_text_part(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, acc) do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, acc, datetime) do
+    decode_text_rows(string, rest, fields, acc, datetime)
   end
 
-  defp decode_text_part(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>, fields, acc) do
-    decode_text_rows(string, rest, fields, acc)
+  defp decode_text_part(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>, fields, acc, datetime) do
+    decode_text_rows(string, rest, fields, acc, datetime)
   end
 
-  defp decode_text_part(<<>>, [], acc) do
+  defp decode_text_part(<<>>, [], acc, _datetime) do
     Enum.reverse(acc)
   end
 
-  defp decode_text_rows(string, rest, [:string | fields], acc) do
-    decode_text_part(rest, fields, [string | acc])
+  defp decode_text_rows(string, rest, [:string | fields], acc, datetime) do
+    decode_text_part(rest, fields, [string | acc], datetime)
   end
 
-  defp decode_text_rows(string, rest, [type | fields], acc)
+  defp decode_text_rows(string, rest, [type | fields], acc, datetime)
    when type in [:uint8, :int8, :uint16, :int16, :uint32, :int32, :uint64, :int64] do
-    decode_text_part(rest, fields, [:erlang.binary_to_integer(string) | acc])
+    decode_text_part(rest, fields, [:erlang.binary_to_integer(string) | acc], datetime)
   end
 
-  defp decode_text_rows(string, rest, [type | fields], acc)
+  defp decode_text_rows(string, rest, [type | fields], acc, datetime)
    when type in [:float32, :float64, :decimal] do
-    decode_text_part(rest, fields, [:erlang.binary_to_float(string) | acc])
+    decode_text_part(rest, fields, [:erlang.binary_to_float(string) | acc], datetime)
   end
 
-  defp decode_text_rows(string, rest, [:bit | fields], acc) do
-    decode_text_part(rest, fields, [string | acc])
+  defp decode_text_rows(string, rest, [:bit | fields], acc, datetime) do
+    decode_text_part(rest, fields, [string | acc], datetime)
   end
 
-  defp decode_text_rows(string, rest, [:time | fields], acc) do
-    decode_text_time(string, rest, fields, acc)
+  defp decode_text_rows(string, rest, [:time | fields], acc, datetime) do
+    decode_text_time(string, rest, fields, acc, datetime)
   end
 
-  defp decode_text_rows(string, rest, [:date | fields], acc) do
-    decode_text_date(string, rest, fields, acc)
+  defp decode_text_rows(string, rest, [:date | fields], acc, datetime) do
+    decode_text_date(string, rest, fields, acc, datetime)
   end
 
-  defp decode_text_rows(string, rest, [:datetime | fields], acc) do
-    decode_text_datetime(string, rest, fields, acc)
+  defp decode_text_rows(string, rest, [:datetime | fields], acc, datetime) do
+    decode_text_datetime(string, rest, fields, acc, datetime)
   end
 
   defmacrop to_int(value) do
     quote do: :erlang.binary_to_integer(unquote(value))
   end
 
-  defp decode_text_date(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>, rest, fields, acc) do
-    decode_text_part(rest, fields, [{to_int(year), to_int(month), to_int(day)} | acc])
+  defp decode_text_date(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>, rest, fields, acc, :structs) do
+    date = %Date{year: to_int(year), month: to_int(month), day: to_int(day)}
+    decode_text_part(rest, fields, [date | acc], :structs)
   end
 
-  defp decode_text_time(<<hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc) do
-    decode_text_part(rest, fields, [{to_int(hour), to_int(min), to_int(sec), 0} | acc])
+  defp decode_text_date(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>, rest, fields, acc, :tuples) do
+    decode_text_part(rest, fields, [{to_int(year), to_int(month), to_int(day)} | acc], :tuples)
+  end
+
+  defp decode_text_time(<<hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc, :structs) do
+    time = %Time{hour: to_int(hour), minute: to_int(min), second: to_int(sec)}
+    decode_text_part(rest, fields, [time | acc], :structs)
+  end
+
+  defp decode_text_time(<<hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc, :tuples) do
+    decode_text_part(rest, fields, [{to_int(hour), to_int(min), to_int(sec), 0} | acc], :tuples)
   end
 
   defp decode_text_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes,
-    _::8-little, hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc) do
-    decode_text_part(rest, fields, [{{to_int(year), to_int(month), to_int(day)}, {to_int(hour), to_int(min), to_int(sec), 0}} | acc])
+    _::8-little, hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc, :structs) do
+    datetime = %NaiveDateTime{year: to_int(year), month: to_int(month), day: to_int(day),
+                              hour: to_int(hour), minute: to_int(min), second: to_int(sec)}
+    decode_text_part(rest, fields, [datetime | acc], :structs)
+  end
+
+  defp decode_text_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes,
+    _::8-little, hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc, :tuples) do
+    decode_text_part(rest, fields, [{{to_int(year), to_int(month), to_int(day)}, {to_int(hour), to_int(min), to_int(sec), 0}} | acc], :tuples)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule Mariaex.Mixfile do
 
   def project do
     [app: :mariaex,
-     version: "0.8.3",
-     elixir: "~> 1.2",
+     version: "0.9.0-dev",
+     elixir: "~> 1.3",
      deps: deps(),
      name: "Mariaex",
      source_url: "https://github.com/liveforeverx/mariaex",

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -2,9 +2,11 @@ defmodule QueryTest do
   use ExUnit.Case, async: true
   import Mariaex.TestHelper
 
-  setup do
-    opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", cache_size: 2, backoff_type: :stop]
-    {:ok, pid} = Mariaex.Connection.start_link(opts)
+  @opts [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", cache_size: 2, backoff_type: :stop]
+
+  setup context do
+    connection_opts = context[:connection_opts] || []
+    {:ok, pid} = Mariaex.Connection.start_link(connection_opts ++ @opts)
     # remove all modes for this session to have the same behaviour on different versions of mysql/mariadb
     {:ok, _} = Mariaex.Connection.query(pid, "SET SESSION sql_mode = \"\";")
     {:ok, [pid: pid]}
@@ -230,8 +232,8 @@ defmodule QueryTest do
   end
 
   test "encode and decode date", context do
-    date0 = {2010, 10, 17}
-    date1 = {0, 0, 0}
+    date0 = ~D[2010-10-17]
+    date1 = ~D[0000-01-01]
     table = "test_dates"
 
     sql = ~s{CREATE TABLE #{table} (id int, d date)}
@@ -247,9 +249,84 @@ defmodule QueryTest do
   end
 
   test "encode and decode time", context do
+    time = ~T[19:27:30]
+    time_with_msec = ~T[10:14:16.23]
+    table = "test_times"
+
+    sql = ~s{CREATE TABLE #{table} (id int, t1 time, t2 time)}
+    :ok = query(sql, [])
+
+    insert = ~s{INSERT INTO #{table} (id, t1, t2) VALUES (?, ?, ?)}
+    :ok = query(insert, [1, time, time_with_msec])
+
+    # Time
+    # Only MySQL 5.7 supports microseconds storage, so it will return 0 here
+    assert query("SELECT t1, t2 FROM #{table} WHERE id = 1", []) == [[~T[19:27:30], ~T[10:14:16]]]
+    assert query("SELECT t1, t2 FROM #{table} WHERE id = ?", [1]) == [[~T[19:27:30], ~T[10:14:16]]]
+    assert query("SELECT time('00:00:00')", []) == [[~T[00:00:00]]]
+  end
+
+  test "encode and decode datetime", context do
+    datetime = ~N[2010-10-17 10:10:30]
+    datetime_with_msec = ~N[2010-10-17 13:32:15.12]
+    table = "test_datetimes"
+
+    sql = ~s{CREATE TABLE #{table} (id int, dt1 datetime, dt2 datetime)}
+    :ok = query(sql, [])
+
+    insert = ~s{INSERT INTO #{table} (id, dt1, dt2) VALUES (?, ?, ?)}
+    :ok = query(insert, [1, datetime, datetime_with_msec])
+
+    # Datetime
+    # Only MySQL 5.7 supports microseconds storage, so it will return 0 here
+    assert query("SELECT dt1, dt2 FROM #{table} WHERE id = 1", []) == [[~N[2010-10-17 10:10:30], ~N[2010-10-17 13:32:15]]]
+    assert query("SELECT dt1, dt2 FROM #{table} WHERE id = ?", [1]) == [[~N[2010-10-17 10:10:30], ~N[2010-10-17 13:32:15]]]
+  end
+
+  test "encode and decode timestamp", context do
+    timestamp = ~N[2010-10-17 10:10:30]
+    timestamp_with_msec = ~N[2010-10-17 13:32:15.12]
+    table = "test_timestamps"
+
+    sql = ~s{CREATE TABLE #{table} (id int, ts1 timestamp, ts2 timestamp)}
+    :ok = query(sql, [])
+
+    insert = ~s{INSERT INTO #{table} (id, ts1, ts2) VALUES (?, ?, ?)}
+    :ok = query(insert, [1, timestamp, timestamp_with_msec])
+
+    # Timestamp
+    # Only MySQL 5.7 supports microseconds storage, so it will return 0 here
+    assert query("SELECT ts1, ts2 FROM #{table} WHERE id = 1", []) == [[~N[2010-10-17 10:10:30], ~N[2010-10-17 13:32:15]]]
+    assert query("SELECT ts1, ts2 FROM #{table} WHERE id = ?", [1]) == [[~N[2010-10-17 10:10:30], ~N[2010-10-17 13:32:15]]]
+    assert query("SELECT timestamp('0000-00-00 00:00:00')", []) == [[~N[0000-01-01 00:00:00]]]
+    assert query("SELECT timestamp('0001-01-01 00:00:00')", []) == [[~N[0001-01-01 00:00:00]]]
+    assert query("SELECT timestamp('2013-12-21 23:01:27')", []) == [[~N[2013-12-21 23:01:27]]]
+    assert query("SELECT timestamp('2013-12-21 23:01:27 EST')", []) == [[~N[2013-12-21 23:01:27]]]
+  end
+
+  @tag connection_opts: [datetime: :tuples]
+  test "encode and decode tuples date", context do
+    date0 = {2010, 10, 17}
+    date1 = {0, 0, 0}
+    table = "test_tuples_dates"
+
+    sql = ~s{CREATE TABLE #{table} (id int, d date)}
+    :ok = query(sql, [])
+
+    insert = ~s{INSERT INTO #{table} (id, d) VALUES (?, ?)}
+    :ok = query(insert, [1, date0])
+    :ok = query(insert, [2, date1])
+
+    assert query("SELECT d FROM #{table} WHERE id = 1", []) == [[date0]]
+    assert query("SELECT d FROM #{table} WHERE id = ?", [1]) == [[date0]]
+    assert query("SELECT d FROM #{table} WHERE id = ?", [2]) == [[date1]]
+  end
+
+  @tag connection_opts: [datetime: :tuples]
+  test "encode and decode tuples time", context do
     time = {19, 27, 30, 0}
     time_with_msec = {10, 14, 16, 23}
-    table = "test_times"
+    table = "test_tuples_times"
 
     sql = ~s{CREATE TABLE #{table} (id int, t1 time, t2 time)}
     :ok = query(sql, [])
@@ -264,12 +341,13 @@ defmodule QueryTest do
     assert query("SELECT time('00:00:00')", []) == [[{0, 0, 0, 0}]]
   end
 
-  test "encode and decode datetime", context do
+  @tag connection_opts: [datetime: :tuples]
+  test "encode and decode tuples datetime", context do
     date = {2010, 10, 17}
     datetime = {date, {10, 10, 30, 0}}
     datetime_with_msec = {date, {13, 32, 15, 12}}
     datetime_no_msec = {date, {10, 10, 29}}
-    table = "test_datetimes"
+    table = "test_tuples_datetimes"
 
     sql = ~s{CREATE TABLE #{table} (id int, dt1 datetime, dt2 datetime, dt3 datetime)}
     :ok = query(sql, [])
@@ -285,11 +363,12 @@ defmodule QueryTest do
     assert query("SELECT COUNT(*) FROM #{table} WHERE dt3 = ?", [datetime_no_msec]) == [[1]]
   end
 
-  test "encode and decode timestamp", context do
+  @tag connection_opts: [datetime: :tuples]
+  test "encode and decode tuples timestamp", context do
     date = {2010, 10, 17}
     timestamp = {date, {10, 10, 30, 0}}
     timestamp_with_msec = {date, {13, 32, 15, 12}}
-    table = "test_timestamps"
+    table = "test_tuples_timestamps"
 
     sql = ~s{CREATE TABLE #{table} (id int, ts1 timestamp, ts2 timestamp)}
     :ok = query(sql, [])

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -243,9 +243,15 @@ defmodule QueryTest do
     :ok = query(insert, [1, date0])
     :ok = query(insert, [2, date1])
 
+    # Strings
+    assert query("SELECT cast(d AS char) FROM #{table} WHERE id = 1", []) == [["2010-10-17"]]
+    assert query("SELECT cast(d AS char) FROM #{table} WHERE id = 2", []) == [["0000-01-01"]]
+
+    # Date
     assert query("SELECT d FROM #{table} WHERE id = 1", []) == [[date0]]
     assert query("SELECT d FROM #{table} WHERE id = ?", [1]) == [[date0]]
     assert query("SELECT d FROM #{table} WHERE id = ?", [2]) == [[date1]]
+    assert query("SELECT date('0000-01-01')", []) == [[date1]]
   end
 
   test "encode and decode time", context do
@@ -258,6 +264,10 @@ defmodule QueryTest do
 
     insert = ~s{INSERT INTO #{table} (id, t1, t2) VALUES (?, ?, ?)}
     :ok = query(insert, [1, time, time_with_msec])
+
+    # Strings
+    assert query("SELECT cast(t1 as char), cast(t2 as char) FROM #{table} WHERE id = 1", []) ==
+           [["19:27:30", "10:14:16"]]
 
     # Time
     # Only MySQL 5.7 supports microseconds storage, so it will return 0 here
@@ -277,6 +287,10 @@ defmodule QueryTest do
     insert = ~s{INSERT INTO #{table} (id, dt1, dt2) VALUES (?, ?, ?)}
     :ok = query(insert, [1, datetime, datetime_with_msec])
 
+    # Strings
+    assert query("SELECT cast(dt1 as char), cast(dt2 as char) FROM #{table} WHERE id = 1", []) ==
+           [["2010-10-17 10:10:30", "2010-10-17 13:32:15"]]
+
     # Datetime
     # Only MySQL 5.7 supports microseconds storage, so it will return 0 here
     assert query("SELECT dt1, dt2 FROM #{table} WHERE id = 1", []) == [[~N[2010-10-17 10:10:30], ~N[2010-10-17 13:32:15]]]
@@ -293,6 +307,10 @@ defmodule QueryTest do
 
     insert = ~s{INSERT INTO #{table} (id, ts1, ts2) VALUES (?, ?, ?)}
     :ok = query(insert, [1, timestamp, timestamp_with_msec])
+
+    # Strings
+    assert query("SELECT cast(ts1 as char), cast(ts2 as char) FROM #{table} WHERE id = 1", []) ==
+           [["2010-10-17 10:10:30", "2010-10-17 13:32:15"]]
 
     # Timestamp
     # Only MySQL 5.7 supports microseconds storage, so it will return 0 here

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -2,9 +2,10 @@ defmodule TextQueryTest do
   use ExUnit.Case, async: true
   import Mariaex.TestHelper
 
+  @opts [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
+
   setup_all do
-    opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
-    {:ok, pid} = Mariaex.Connection.start_link(opts)
+    {:ok, pid} = Mariaex.Connection.start_link(@opts)
     # drop = "DROP TABLE IF EXISTS test"
     # {:ok, _} = Mariaex.execute(pid, %Mariaex.Query{type: :text, statement: drop}, [])
     create = """
@@ -58,16 +59,28 @@ defmodule TextQueryTest do
 
   test "select timestamp", context do
     rows = execute_text("SELECT ts FROM test_text_query_table", [])
-    assert(rows == [[{{2016, 9, 26}, {16, 36, 06, 0}}], [{{2016, 9, 26}, {16, 36, 07, 0}}]])
+    assert(rows == [[~N[2016-09-26 16:36:06]], [~N[2016-09-26 16:36:07]]])
   end
 
   test "select datetime", context do
     rows = execute_text("SELECT dt FROM test_text_query_table", [])
-    assert(rows == [[{{1,1,1}, {0,0,0,0}}], [{{1,1,1}, {0,0,1,0}}]])
+    assert(rows == [[~N[0001-01-01 00:00:00]], [~N[0001-01-01 00:00:01]]])
   end
 
   test "select multiple columns", context do
     rows = execute_text("SELECT id, varchars FROM test_text_query_table", [])
     assert(rows == [[1, "hello"], [2, "goodbye"]])
+  end
+
+  test "select tuple timestamp" do
+    {:ok, pid} = Mariaex.Connection.start_link([datetime: :tuples] ++ @opts)
+    {:ok, %{rows: rows}} = Mariaex.query(pid, "SELECT ts FROM test_text_query_table", [], query_type: :text)
+    assert(rows == [[{{2016, 9, 26}, {16, 36, 06, 0}}], [{{2016, 9, 26}, {16, 36, 07, 0}}]])
+  end
+
+  test "select tuple datetime" do
+    {:ok, pid} = Mariaex.Connection.start_link([datetime: :tuples] ++ @opts)
+    {:ok, %{rows: rows}} = Mariaex.query(pid, "SELECT dt FROM test_text_query_table", [], query_type: :text)
+    assert(rows == [[{{1,1,1}, {0,0,0,0}}], [{{1,1,1}, {0,0,1,0}}]])
   end
 end


### PR DESCRIPTION
This pull request adds support for Elixir Calendar types. It keeps the old types available under the `datetime: :tuples` option but defaults to the new types. This PR also bumps the Elixir requirement in the `mix.exs` and for this reason bumps the version to 0.9.0-dev.