### PR TITLE
Add json column support mysql(5.7~)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ notifications:
 sudo: false
 env:
     matrix:
-        - DB=mariadb:10.1
-        - DB=mariadb:10.2
-        - DB=mariadb:10.3
-        - DB=mysql:8.0
-        - DB=mysql:5.7
-        - DB=mysql:5.6
+        - DB=mariadb:10.1 JSON_SUPPORT=false
+        - DB=mariadb:10.2 JSON_SUPPORT=false
+        - DB=mariadb:10.3 JSON_SUPPORT=false
+        - DB=mysql:8.0 JSON_SUPPORT=true
+        - DB=mysql:5.7 JSON_SUPPORT=true
+        - DB=mysql:5.6 JSON_SUPPORT=false
 before_install:
     - sudo service mysql stop
     - docker pull $DB || true
     - docker run --name mariadb -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -d $DB
-script: "mix test --cover"
+script: "JSON_SUPPORT=$JSON_SUPPORT mix test --cover"

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ After you are done, run `mix deps.get` in your shell to fetch and compile Mariae
 
 Important configuration, which depends on used charset for support unicode chars, see `:binary_as`
 in `Mariaex.start_link/1`
+
+### JSON library
+
+As default, [Poison](https://github.com/devinus/poison) is used for JSON library in mariaex to support JSON column.
+
+If you want to use another library, please set `config.exs` like below.
+
+```elixir
+config :mariaex, json_library: SomeLibrary
+```

--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -66,7 +66,6 @@ defmodule Mariaex do
     in `GenServer.start_link/3`).
     * `:datetime` - How datetimes should be returned. `:structs` for Elixir v1.3
       calendar types or `:tuples` for the backwards compatible tuples
-    * `:json_library` - JSON Library to parse json column. (default: `Poison`)
 
   ## Function signatures
 

--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -66,6 +66,7 @@ defmodule Mariaex do
     in `GenServer.start_link/3`).
     * `:datetime` - How datetimes should be returned. `:structs` for Elixir v1.3
       calendar types or `:tuples` for the backwards compatible tuples
+    * `:json_library` - JSON Library to parse json column. (default: `Poison`)
 
   ## Function signatures
 

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -246,17 +246,17 @@ defmodule Mariaex.Messages do
   end
 
   def decode_text_rows(<< len :: size(24)-little-integer, seqnum :: size(8)-integer, body :: size(len)-binary, rest :: binary>>,
-                      fields, rows, datetime) do
+                      fields, rows, datetime, json_library) do
     case body do
       << 254 :: 8, _ :: binary >> = body when byte_size(body) < 9 ->
         msg = decode_msg(body, :text_rows)
         {:ok, packet(size: len, seqnum: seqnum, msg: msg, body: body), rows, rest}
       body ->
-        row = Mariaex.RowParser.decode_text_rows(body, fields, datetime)
-        decode_text_rows(rest, fields, [row | rows], datetime)
+        row = Mariaex.RowParser.decode_text_rows(body, fields, datetime, json_library)
+        decode_text_rows(rest, fields, [row | rows], datetime, json_library)
     end
   end
-  def decode_text_rows(<<rest :: binary>>, _fields, rows, _datetime) do
+  def decode_text_rows(<<rest :: binary>>, _fields, rows, _datetime, _json_library) do
     {:more, rows, rest}
   end
 

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -67,6 +67,8 @@ defmodule Mariaex.Messages do
             field_type_blob: 0xfc,
             field_type_var_string: 0xfd,
             field_type_string: 0xfe],
+          json:
+           [field_type_json: 0xf5],
           null:
            [field_type_null: 0x06]
          ]

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -231,17 +231,17 @@ defmodule Mariaex.Messages do
     do: {nil, rest}
 
   def decode_bin_rows(<< len :: size(24)-little-integer, seqnum :: size(8)-integer, body :: size(len)-binary, rest :: binary>>,
-                      fields, nullbin_size, rows, datetime) do
+                      fields, nullbin_size, rows, datetime, json_library) do
     case body do
       <<0 :: 8, nullbin::size(nullbin_size)-little-unit(8), values :: binary>> ->
-        row = Mariaex.RowParser.decode_bin_rows(values, fields, nullbin, datetime)
-        decode_bin_rows(rest, fields, nullbin_size, [row | rows], datetime)
+        row = Mariaex.RowParser.decode_bin_rows(values, fields, nullbin, datetime, json_library)
+        decode_bin_rows(rest, fields, nullbin_size, [row | rows], datetime, json_library)
       body ->
         msg = decode_msg(body, :bin_rows)
         {:ok, packet(size: len, seqnum: seqnum, msg: msg, body: body), rows, rest}
     end
   end
-  def decode_bin_rows(<<rest :: binary>>, _fields, _nullbin_size, rows, _datetime) do
+  def decode_bin_rows(<<rest :: binary>>, _fields, _nullbin_size, rows, _datetime, _json_library) do
     {:more, rows, rest}
   end
 

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -641,8 +641,8 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp binary_row_decode(%{datetime: datetime} = s, fields, nullbin_size, rows, buffer) do
-    case decode_bin_rows(buffer, fields, nullbin_size, rows, datetime) do
+  defp binary_row_decode(%{datetime: datetime, json_library: json_library} = s, fields, nullbin_size, rows, buffer) do
+    case decode_bin_rows(buffer, fields, nullbin_size, rows, datetime, json_library) do
       {:ok, packet, rows, rest} ->
         {:ok, packet, rows, %{s | buffer: rest}}
       {:more, rows, rest} ->

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -62,6 +62,7 @@ defmodule Mariaex.Protocol do
             cursors: %{},
             seqnum: 0,
             datetime: :structs,
+            json_library: Poison,
             ssl_conn_state: :undefined  #  :undefined | :not_used | :ssl_handshake | :connected
 
   @doc """
@@ -76,6 +77,7 @@ defmodule Mariaex.Protocol do
     connect_opts = [host, opts[:port], opts[:socket_options], opts[:timeout]]
     binary_as    = opts[:binary_as] || :field_type_var_string
     datetime     = opts[:datetime] || :structs
+    json_library = opts[:json_library] || Poison
 
     case apply(sock_mod, :connect, connect_opts) do
       {:ok, sock} ->
@@ -88,6 +90,7 @@ defmodule Mariaex.Protocol do
                         lru_cache: reset_lru_cache(opts[:cache_size]),
                         timeout: opts[:timeout],
                         datetime: datetime,
+                        json_library: json_library,
                         opts: opts}
         handshake_recv(s, %{opts: opts})
       {:error, reason} ->

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -77,7 +77,7 @@ defmodule Mariaex.Protocol do
     connect_opts = [host, opts[:port], opts[:socket_options], opts[:timeout]]
     binary_as    = opts[:binary_as] || :field_type_var_string
     datetime     = opts[:datetime] || :structs
-    json_library = opts[:json_library] || Poison
+    json_library = Application.get_env(:mariaex, :json_library, Poison)
 
     case apply(sock_mod, :connect, connect_opts) do
       {:ok, sock} ->

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -534,8 +534,8 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp text_row_decode(%{datetime: datetime} = s, fields, rows, buffer) do
-    case decode_text_rows(buffer, fields, rows, datetime) do
+  defp text_row_decode(%{datetime: datetime, json_library: json_library} = s, fields, rows, buffer) do
+    case decode_text_rows(buffer, fields, rows, datetime, json_library) do
       {:ok, packet, rows, rest} ->
         {:ok, packet, rows, %{s | buffer: rest}}
       {:more, rows, rest} ->

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -66,6 +66,10 @@ defmodule Mariaex.RowParser do
     :int64
   end
 
+  defp type_to_atom({:json, :field_type_json}, _) do
+    :json
+  end
+
   defp type_to_atom({:string, _mysql_type}, _),              do: :string
   defp type_to_atom({:integer, :field_type_year}, _),        do: :uint16
   defp type_to_atom({:time, :field_type_time}, _),           do: :time

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -20,8 +20,8 @@ defmodule Mariaex.RowParser do
     {fields, div(length(fields) + 7 + 2, 8)}
   end
 
-  def decode_bin_rows(row, fields, nullint, datetime) do
-    decode_bin_rows(row, fields, nullint >>> 2, [], datetime)
+  def decode_bin_rows(row, fields, nullint, datetime, json_library) do
+    decode_bin_rows(row, fields, nullint >>> 2, [], datetime, json_library)
   end
 
   ## Helpers
@@ -82,252 +82,252 @@ defmodule Mariaex.RowParser do
   defp type_to_atom({:bit, :field_type_bit}, _),             do: :bit
   defp type_to_atom({:null, :field_type_null}, _),           do: nil
 
-  defp decode_bin_rows(<<rest::bits>>, [_ | fields], nullint, acc, datetime) when (nullint &&& 1) === 1 do
-    decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc], datetime)
+  defp decode_bin_rows(<<rest::bits>>, [_ | fields], nullint, acc, datetime, json_library) when (nullint &&& 1) === 1 do
+    decode_bin_rows(rest, fields, nullint >>> 1, [nil | acc], datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:string | fields], null_bitfield,  acc, datetime) do
-    decode_string(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:string | fields], null_bitfield,  acc, datetime, json_library) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint8 | fields], null_bitfield, acc, datetime) do
-    decode_uint8(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:uint8 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_uint8(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int8 | fields], null_bitfield, acc, datetime) do
-    decode_int8(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:int8 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_int8(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint16 | fields], null_bitfield, acc, datetime) do
-    decode_uint16(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:uint16 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_uint16(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int16 | fields], null_bitfield, acc, datetime) do
-    decode_int16(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:int16 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_int16(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint32 | fields], null_bitfield, acc, datetime) do
-    decode_uint32(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:uint32 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_uint32(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int32 | fields], null_bitfield, acc, datetime) do
-    decode_int32(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:int32 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_int32(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:uint64 | fields], null_bitfield, acc, datetime) do
-    decode_uint64(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:uint64 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_uint64(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:int64 | fields], null_bitfield, acc, datetime) do
-    decode_int64(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:int64 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_int64(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:time | fields], null_bitfield, acc, datetime) do
-    decode_time(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:time | fields], null_bitfield, acc, datetime, json_library) do
+    decode_time(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:date | fields], null_bitfield, acc, datetime) do
-    decode_date(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:date | fields], null_bitfield, acc, datetime, json_library) do
+    decode_date(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:datetime | fields], null_bitfield, acc, datetime) do
-    decode_datetime(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:datetime | fields], null_bitfield, acc, datetime, json_library) do
+    decode_datetime(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:decimal | fields], null_bitfield, acc, datetime) do
-    decode_decimal(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:decimal | fields], null_bitfield, acc, datetime, json_library) do
+    decode_decimal(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:float32 | fields], null_bitfield, acc, datetime) do
-    decode_float32(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:float32 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_float32(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:float64 | fields], null_bitfield, acc, datetime) do
-    decode_float64(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:float64 | fields], null_bitfield, acc, datetime, json_library) do
+    decode_float64(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:bit | fields], null_bitfield, acc, datetime) do
-    decode_string(rest, fields, null_bitfield >>> 1, acc, datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:bit | fields], null_bitfield, acc, datetime, json_library) do
+    decode_string(rest, fields, null_bitfield >>> 1, acc, datetime, json_library)
   end
 
-  defp decode_bin_rows(<<rest::bits>>, [:nil | fields], null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc], datetime)
+  defp decode_bin_rows(<<rest::bits>>, [:nil | fields], null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield >>> 1, [nil | acc], datetime, json_library)
   end
 
-  defp decode_bin_rows(<<>>, [], _, acc, _datetime) do
+  defp decode_bin_rows(<<>>, [], _, acc, _datetime, _json_library) do
     Enum.reverse(acc)
   end
 
-  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime) when len <= 250 do
-    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
+  defp decode_string(<<len::8, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime, json_library) when len <= 250 do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime, json_library)
   end
 
-  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
+  defp decode_string(<<252::8, len::16-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime, json_library)
   end
 
-  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
+  defp decode_string(<<253::8, len::24-little, string::size(len)-binary, rest::bits>>, fields, nullint,  acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime, json_library)
   end
 
-  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>,  fields, nullint,  acc, datetime) do
-    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime)
+  defp decode_string(<<254::8, len::64-little, string::size(len)-binary, rest::bits>>,  fields, nullint,  acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, nullint,  [string | acc], datetime, json_library)
   end
 
-  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime)
+  defp decode_float32(<<value::size(32)-float-little, rest::bits>>, fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime, json_library)
   end
 
-  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime)
+  defp decode_float64(<<value::size(64)-float-little, rest::bits>>, fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime, json_library)
   end
 
   defp decode_uint8(<<value::size(8)-little-unsigned, rest::bits>>,
-                    fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                    fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_int8(<<value::size(8)-little-signed, rest::bits>>,
-                   fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                   fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_uint16(<<value::size(16)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                     fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_int16(<<value::size(16)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                    fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_uint32(<<value::size(32)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                     fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_int32(<<value::size(32)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                    fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_uint64(<<value::size(64)-little-unsigned, rest::bits>>,
-                     fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                     fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_int64(<<value::size(64)-little-signed, rest::bits>>,
-                    fields, null_bitfield, acc, datetime) do
-    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime)
+                    fields, null_bitfield, acc, datetime, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield , [value | acc], datetime, json_library)
   end
 
   defp decode_decimal(<<length,  raw_value::size(length)-little-binary, rest::bits>>,
-                      fields, null_bitfield, acc, datetime) do
+                      fields, null_bitfield, acc, datetime, json_library) do
     value = Decimal.new(raw_value)
-    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime)
+    decode_bin_rows(rest, fields, null_bitfield, [value | acc], datetime, json_library)
   end
 
   defp decode_time(<< 0::8-little, rest::bits>>,
-                   fields, null_bitfield, acc, :structs) do
+                   fields, null_bitfield, acc, :structs, json_library) do
     time = %Time{hour: 0, minute: 0, second: 0}
-    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs, json_library)
   end
 
   defp decode_time(<<8::8-little, _::8-little, _::32-little, hour::8-little, min::8-little, sec::8-little, rest::bits>>,
-                   fields, null_bitfield, acc, :structs) do
+                   fields, null_bitfield, acc, :structs, json_library) do
     time = %Time{hour: hour, minute: min, second: sec}
-    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs, json_library)
   end
 
   defp decode_time(<< 12::8, _::32-little, _::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                   fields, null_bitfield, acc, :structs) do
+                   fields, null_bitfield, acc, :structs, json_library) do
     time = %Time{hour: hour, minute: min, second: sec, microsecond: {msec, 6}}
-    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [time | acc], :structs, json_library)
   end
 
   defp decode_time(<< 0::8-little, rest::bits>>,
-                   fields, null_bitfield, acc, :tuples) do
-    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc], :tuples)
+                   fields, null_bitfield, acc, :tuples, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0, 0} | acc], :tuples, json_library)
   end
 
   defp decode_time(<<8::8-little, _::8-little, _::32-little, hour::8-little, min::8-little, sec::8-little, rest::bits>>,
-                   fields, null_bitfield, acc, :tuples) do
-    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc], :tuples)
+                   fields, null_bitfield, acc, :tuples, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, 0} | acc], :tuples, json_library)
   end
 
   defp decode_time(<< 12::8, _::32-little, _::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                   fields, null_bitfield, acc, :tuples) do
+                   fields, null_bitfield, acc, :tuples, json_library) do
 
-    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc], :tuples)
+    decode_bin_rows(rest, fields, null_bitfield, [{hour, min, sec, msec} | acc], :tuples, json_library)
   end
 
   defp decode_date(<< 0::8-little, rest::bits >>,
-                   fields, null_bitfield, acc, :structs) do
+                   fields, null_bitfield, acc, :structs, json_library) do
     date = %Date{year: 0, month: 1, day: 1}
-    decode_bin_rows(rest, fields, null_bitfield, [date | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [date | acc], :structs, json_library)
   end
 
   defp decode_date(<< 4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                   fields, null_bitfield, acc, :structs) do
+                   fields, null_bitfield, acc, :structs, json_library) do
     date = %Date{year: year, month: month, day: day}
-    decode_bin_rows(rest, fields, null_bitfield, [date | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [date | acc], :structs, json_library)
   end
 
   defp decode_date(<< 0::8-little, rest::bits >>,
-                   fields, null_bitfield, acc, :tuples) do
-    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc], :tuples)
+                   fields, null_bitfield, acc, :tuples, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{0, 0, 0} | acc], :tuples, json_library)
   end
 
   defp decode_date(<< 4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                   fields, null_bitfield, acc, :tuples) do
+                   fields, null_bitfield, acc, :tuples, json_library) do
 
-    decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc], :tuples)
+    decode_bin_rows(rest, fields, null_bitfield, [{year, month, day} | acc], :tuples, json_library)
   end
 
 
   defp decode_datetime(<< 0::8-little, rest::bits >>,
-                       fields, null_bitfield, acc, :structs) do
+                       fields, null_bitfield, acc, :structs, json_library) do
     datetime = %NaiveDateTime{year: 0, month: 1, day: 1, hour: 0, minute: 0, second: 0}
-    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs, json_library)
   end
 
   defp decode_datetime(<<4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                       fields, null_bitfield, acc, :structs) do
+                       fields, null_bitfield, acc, :structs, json_library) do
     datetime = %NaiveDateTime{year: year, month: month, day: day, hour: 0, minute: 0, second: 0}
-    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs, json_library)
   end
 
   defp decode_datetime(<< 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, rest::bits >>,
-                       fields, null_bitfield, acc, :structs) do
+                       fields, null_bitfield, acc, :structs, json_library) do
     datetime = %NaiveDateTime{year: year, month: month, day: day, hour: hour, minute: min, second: sec}
-    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs, json_library)
   end
 
   defp decode_datetime(<<11::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                       fields, null_bitfield, acc, :structs) do
+                       fields, null_bitfield, acc, :structs, json_library) do
     datetime = %NaiveDateTime{year: year, month: month, day: day, hour: hour, minute: min, second: sec, microsecond: {msec, 6}}
-    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs)
+    decode_bin_rows(rest, fields, null_bitfield, [datetime | acc], :structs, json_library)
   end
 
   defp decode_datetime(<< 0::8-little, rest::bits >>,
-                       fields, null_bitfield, acc, :tuples) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc], :tuples)
+                       fields, null_bitfield, acc, :tuples, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{0, 0, 0}, {0, 0, 0, 0}} | acc], :tuples, json_library)
   end
 
   defp decode_datetime(<<4::8-little, year::16-little, month::8-little, day::8-little, rest::bits >>,
-                       fields, null_bitfield, acc, :tuples) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc], :tuples)
+                       fields, null_bitfield, acc, :tuples, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {0, 0, 0, 0}} | acc], :tuples, json_library)
   end
 
   defp decode_datetime(<< 7::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, rest::bits >>,
-                       fields, null_bitfield, acc, :tuples) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc], :tuples)
+                       fields, null_bitfield, acc, :tuples, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, 0}} | acc], :tuples, json_library)
   end
 
   defp decode_datetime(<<11::8-little, year::16-little, month::8-little, day::8-little, hour::8-little, min::8-little, sec::8-little, msec::32-little, rest::bits >>,
-                       fields, null_bitfield, acc, :tuples) do
-    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc], :tuples)
+                       fields, null_bitfield, acc, :tuples, json_library) do
+    decode_bin_rows(rest, fields, null_bitfield, [{{year, month, day}, {hour, min, sec, msec}} | acc], :tuples, json_library)
   end
 
   ### TEXT ROW PARSER

--- a/lib/mariaex/row_parser.ex
+++ b/lib/mariaex/row_parser.ex
@@ -395,6 +395,10 @@ defmodule Mariaex.RowParser do
     decode_text_datetime(string, rest, fields, acc, datetime, json_library)
   end
 
+  defp decode_text_rows(string, rest, [:json | fields], acc, datetime, json_library) do
+    decode_text_json(string, rest, fields, acc, datetime, json_library)
+  end
+
   defmacrop to_int(value) do
     quote do: :erlang.binary_to_integer(unquote(value))
   end
@@ -427,5 +431,10 @@ defmodule Mariaex.RowParser do
   defp decode_text_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes,
     _::8-little, hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes>>, rest, fields, acc, :tuples, json_library) do
     decode_text_part(rest, fields, [{{to_int(year), to_int(month), to_int(day)}, {to_int(hour), to_int(min), to_int(sec), 0}} | acc], :tuples, json_library)
+  end
+
+  defp decode_text_json(string, rest, fields, acc, datetime, json_library) do
+    json = json_library.decode!(string)
+    decode_text_part(rest, fields, [json | acc], datetime, json_library)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule Mariaex.Mixfile do
     [{:decimal, "~> 1.0"},
      {:db_connection, "~> 1.1"},
      {:coverex, "~> 1.4.10", only: :test},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+     {:ex_doc, ">= 0.0.0", only: :dev},
+     {:poison, "~> 2.1", optional: true}]
   end
 
   defp description do

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Mariaex.Mixfile do
      {:db_connection, "~> 1.1"},
      {:coverex, "~> 1.4.10", only: :test},
      {:ex_doc, ">= 0.0.0", only: :dev},
-     {:poison, "~> 2.1", optional: true}]
+     {:poison, ">= 0.0.0", optional: true}]
   end
 
   defp description do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -685,4 +685,21 @@ defmodule QueryTest do
     assert :ok = query("REPLACE INTO test_replace VALUES (1, 'Old', '2014-08-20 18:47:00');", [])
     assert :ok = query("REPLACE INTO test_replace VALUES (1, 'New', ?);", [timestamp])
   end
+
+  if System.get_env("JSON_SUPPORT") === "true" do
+    test "encode and decode json", context do
+      map = %{"hoge" => "1", "huga" => "2"}
+      map_string = ~s|{"hoge": "1", "huga": "2"}|
+
+      table = "test_jsons"
+
+      sql = ~s{CREATE TABLE #{table} (id int, map json)}
+      :ok = query(sql, [])
+
+      insert = ~s{INSERT INTO #{table} (id, map) VALUES (?, ?)}
+      :ok = query(insert, [1, map_string])
+
+      assert query("SELECT map FROM #{table} WHERE id = 1", []) == [[map]]
+    end
+  end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -686,20 +686,19 @@ defmodule QueryTest do
     assert :ok = query("REPLACE INTO test_replace VALUES (1, 'New', ?);", [timestamp])
   end
 
-  if System.get_env("JSON_SUPPORT") === "true" do
-    test "encode and decode json", context do
-      map = %{"hoge" => "1", "huga" => "2"}
-      map_string = ~s|{"hoge": "1", "huga": "2"}|
+  @tag :json
+  test "encode and decode json", context do
+    map = %{"hoge" => "1", "huga" => "2"}
+    map_string = ~s|{"hoge": "1", "huga": "2"}|
 
-      table = "test_jsons"
+    table = "test_jsons"
 
-      sql = ~s{CREATE TABLE #{table} (id int, map json)}
-      :ok = query(sql, [])
+    sql = ~s{CREATE TABLE #{table} (id int, map json)}
+    :ok = query(sql, [])
 
-      insert = ~s{INSERT INTO #{table} (id, map) VALUES (?, ?)}
-      :ok = query(insert, [1, map_string])
+    insert = ~s{INSERT INTO #{table} (id, map) VALUES (?, ?)}
+    :ok = query(insert, [1, map_string])
 
-      assert query("SELECT map FROM #{table} WHERE id = 1", []) == [[map]]
-    end
+    assert query("SELECT map FROM #{table} WHERE id = 1", []) == [[map]]
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.configure exclude: [:ssl_tests]
+ExUnit.configure exclude: [ssl_tests: :true, json: System.get_env("JSON_SUPPORT") != "true"]
 ExUnit.start()
 
 run_cmd = fn cmd ->

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -102,12 +102,11 @@ defmodule TextQueryTest do
     assert(rows == [[{{1,1,1}, {0,0,0,0}}], [{{1,1,1}, {0,0,1,0}}]])
   end
 
-  if System.get_env("JSON_SUPPORT") === "true" do
-    test "select json", context do
-      opts = [json_library: Poison]
+  @tag :json
+  test "select json", context do
+    opts = [json_library: Poison]
 
-      rows = execute_text("SELECT map FROM test_text_json_query_table", [], opts)
-      assert(rows == [[%{"hoge" => "1", "huga" => "2"}], [%{"hoge" => "3", "huga" => "4"}]])
-    end
+    rows = execute_text("SELECT map FROM test_text_json_query_table", [], opts)
+    assert(rows == [[%{"hoge" => "1", "huga" => "2"}], [%{"hoge" => "3", "huga" => "4"}]])
   end
 end

--- a/test/text_query_test.exs
+++ b/test/text_query_test.exs
@@ -28,6 +28,24 @@ defmodule TextQueryTest do
     (2, false, b'11', 'goodbye', 'earth', 1.2, '2016-09-26T16:36:07', '0001-01-01 00:00:01')
     """
     {:ok, _} = Mariaex.query(pid, insert, [], [query_type: :text])
+
+    if System.get_env("JSON_SUPPORT") === "true" do
+      create = """
+      CREATE TABLE test_text_json_query_table (
+      id serial,
+      map json,
+      dt datetime
+      )
+      """
+      {:ok, _} = Mariaex.query(pid, create, [], [query_type: :text])
+      insert = """
+      INSERT INTO test_text_json_query_table (id, map, dt)
+      VALUES
+      (1, '{"hoge": "1", "huga": "2"}', '2017-01-01 00:00:00'),
+      (2, '{"hoge": "3", "huga": "4"}', '2017-01-01 00:00:01')
+      """
+      {:ok, _} = Mariaex.query(pid, insert, [], [query_type: :text])
+    end
     {:ok, [pid: pid]}
   end
 
@@ -82,5 +100,14 @@ defmodule TextQueryTest do
     {:ok, pid} = Mariaex.Connection.start_link([datetime: :tuples] ++ @opts)
     {:ok, %{rows: rows}} = Mariaex.query(pid, "SELECT dt FROM test_text_query_table", [], query_type: :text)
     assert(rows == [[{{1,1,1}, {0,0,0,0}}], [{{1,1,1}, {0,0,1,0}}]])
+  end
+
+  if System.get_env("JSON_SUPPORT") === "true" do
+    test "select json", context do
+      opts = [json_library: Poison]
+
+      rows = execute_text("SELECT map FROM test_text_json_query_table", [], opts)
+      assert(rows == [[%{"hoge" => "1", "huga" => "2"}], [%{"hoge" => "3", "huga" => "4"}]])
+    end
   end
 end


### PR DESCRIPTION
fixes #119 . (This pull request is re-creation for #176 .)

Encode and decode library for json can choose by `opts[:json_library]` (Default set to `Poison`).