### PR TITLE
Clean up Mariex.Result module doc

### DIFF
--- a/lib/mariaex/structs.ex
+++ b/lib/mariaex/structs.ex
@@ -2,11 +2,9 @@ defmodule Mariaex.Result do
   @moduledoc """
   Result struct returned from any successful query. Its fields are:
 
-    * `command` - An atom of the query command, for example: `:select` or
-                  `:insert`;
     * `columns` - The column names;
     * `rows` - The result set. A list of tuples, each tuple corresponding to a
-               row, each element in the tuple corresponds to a column;
+      row, each element in the tuple corresponds to a column;
     * `num_rows` - The number of fetched or affected rows;
   """
 


### PR DESCRIPTION
Remove `command` field because structure doesn't have it and fix
formatting in rendered doc for `rows` element in the fields list.