### PR TITLE
Replace "SET CHARACTER SET" with "SET NAMES" in protocol.ex

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -217,7 +217,7 @@ defmodule Mariaex.Protocol do
     handshake_recv(%{s | state: :handshake_send, deprecated_eof: deprecated_eof}, nil)
   end
   defp handle_handshake(packet(msg: ok_resp(affected_rows: _affected_rows, last_insert_id: _last_insert_id) = _packet), nil, state) do
-    statement = "SET CHARACTER SET " <> (state.opts[:charset] || "utf8")
+    statement = "SET NAMES " <> (state.opts[:charset] || "utf8")
     query = %Query{type: :text, statement: statement}
     case send_text_query(state, statement) |> text_query_recv(query) do
       {:error, error, _} ->


### PR DESCRIPTION
According to [1] and [2], "SET CHARACTER SET" will change
character_set_connection to unexpected value.

The case is a database with latin1 character set and collation, but
table with custom default character, records with utf8 fields will be
inserted into database with latin1 encoding.

[1]: https://dev.mysql.com/doc/refman/5.7/en/charset-connection.html
[2]: https://stackoverflow.com/questions/1650591/whether-to-use-set-names