### PR TITLE
Match a ping error in mariaex protocol.ex

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -1143,6 +1143,10 @@ defmodule Mariaex.Protocol do
     {:ok, state}
   end
 
+  defp ping_handle(error = packet(msg: error_resp()), :ping, %{buffer: buffer} = state) when is_binary(buffer) do
+    {:disconnect, error,  state}
+  end
+
   defp send_text_query(s, statement) do
     msg_send(text_cmd(command: com_query(), statement: statement), s, 0)
     %{s | state: :column_count}

--- a/test/mariaex/protocol_test.exs
+++ b/test/mariaex/protocol_test.exs
@@ -1,0 +1,21 @@
+defmodule Mariaex.ProtocolTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  describe "Integration test" do
+    test "Expect to disconnect from the database when it goes down" do
+      Process.flag(:trap_exit, true)
+      opts = [database: "information_schema", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop, sync_connect: true]
+
+      log = capture_log(fn ->
+        assert {:ok, pid} = Mariaex.start_link(opts)
+        # Restart the docker container to assure that mariadb will stop
+        # responding to ping(s)
+        System.cmd("docker", ["restart", "mariadb"])
+      end)
+
+      # Check if we disconnected
+      assert log =~ "disconnected"
+    end
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/xerions/mariaex/issues/217

Behaviour after the change in this PR:

```elixir
iex(1)> opts = [database: "information_schema", username: "mariaex_user", password: "mariaex_pass", backoff_type: :rand_exp, sync_connect: true]
[
  database: "information_schema",
  username: "mariaex_user",
  password: "mariaex_pass",
  backoff_type: :rand_exp,
  sync_connect: true
]
iex(2)> {:ok, pid} = Mariaex.start_link(opts)                                                                                                   
{:ok, #PID<0.200.0>}
iex(3)> # I shutdown the db for some moments
nil
iex(4)> 
20:02:46.170 [error] Mariaex.Protocol (#PID<0.200.0>) disconnected: ** (ErlangError) Erlang error: {:packet, 30, 0, {:error_resp, 255, 1927, "#", "70100", "Connection was killed"}, <<255, 135, 7, 35, 55, 48, 49, 48, 48, 67, 111, 110, 110, 101, 99, 116, 105, 111, 110, 32, 119, 97, 115, 32, 107, 105, 108, 108, 101, 100>>}
 
20:02:46.171 [error] Mariaex.Protocol (#PID<0.200.0>) failed to connect: ** (Mariaex.Error) tcp connect: econnrefused
 
20:02:48.116 [error] Mariaex.Protocol (#PID<0.200.0>) failed to connect: ** (Mariaex.Error) tcp connect: econnrefused
# Now I should be re-connected to the db
nil
iex(5)> Mariaex.query(pid, "SELECT 42") 
{:ok,
 %Mariaex.Result{
   columns: ["42"],
   connection_id: #PID<0.200.0>,
   last_insert_id: nil,
   num_rows: 1,
   rows: ['*']
 }}

```

#### Work in Progress
* [ ] Tests 