### PR TITLE
Fix typespec and README for rows as lists not tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After you are done, run `mix deps.get` in your shell to fetch and compile Mariae
   iex(5)> Mariaex.query(p, "SELECT id, title FROM test1")
   {:ok,
    %Mariaex.Result{columns: ["id", "title"], command: :select, num_rows: 2,
-    rows: [{1, "test"}, {2, "test2"}]}}
+    rows: [[1, "test"], [2, "test2"]}}
 ```
 
 ## Configuration

--- a/lib/mariaex/structs.ex
+++ b/lib/mariaex/structs.ex
@@ -3,14 +3,14 @@ defmodule Mariaex.Result do
   Result struct returned from any successful query. Its fields are:
 
     * `columns` - The column names;
-    * `rows` - The result set. A list of tuples, each tuple corresponding to a
-      row, each element in the tuple corresponds to a column;
+    * `rows` - The result set. A list of lists, each list corresponding to a
+      row, each element of the inner list corresponds to a column value;
     * `num_rows` - The number of fetched or affected rows;
   """
 
   @type t :: %__MODULE__{
     columns:  [String.t] | nil,
-    rows:     [tuple] | nil,
+    rows:     [[any]] | nil,
     last_insert_id: integer,
     num_rows: integer,
     connection_id: nil}


### PR DESCRIPTION
Looks like it was changed from tuples to lists in 0.4