### PR TITLE
Make default character set consequent

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -187,7 +187,7 @@ defmodule Mariaex.Protocol do
   defp handle_handshake(packet(seqnum: seqnum) = packet, opts, %{ssl_conn_state: :ssl_handshake} = s) do
     # Create and send an SSL request packet per the spec:
     # https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
-    msg = ssl_connection_request(capability_flags: ssl_capabilities(opts), max_size: @maxpacketbytes, character_set: 8)
+    msg = ssl_connection_request(capability_flags: ssl_capabilities(opts), max_size: @maxpacketbytes, character_set: 33)
     msg_send(msg, s, new_seqnum = seqnum + 1)
     case upgrade_to_ssl(s, opts) do
       {:ok, new_state} ->
@@ -212,7 +212,7 @@ defmodule Mariaex.Protocol do
     {database, capabilities} = capabilities(opts)
     msg = handshake_resp(username: :unicode.characters_to_binary(opts[:username]), password: scramble,
                          database: database, capability_flags: capabilities,
-                         max_size: @maxpacketbytes, character_set: 8)
+                         max_size: @maxpacketbytes, character_set: 33)
     msg_send(msg, s, seqnum + 1)
     handshake_recv(%{s | state: :handshake_send, deprecated_eof: deprecated_eof}, nil)
   end


### PR DESCRIPTION
In MariaEx, the default character defaults to `utf8`. However, the initial client negotiation (the first client response after the `server greeting`) is currently hardcoded at character set 8 (which is `latin1 COLLATE latin1_swedish_ci`):

<img width="834" alt="screen shot 2018-08-30 at 19 22 15" src="https://user-images.githubusercontent.com/80709/44868318-c5468e80-ac8a-11e8-878a-9d33a610ec02.png">

To make the behaviour of MariaEx consequent, this PR changes the initial client negotiation to character set 33 (which is `utf8 COLLATE utf8_general_ci`).
