### PR TITLE
Reduce amount of prepared statements (v0.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ erl_crash.dump
 .compile.elixir
 *.swp
 /doc
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 .compile.elixir
 *.swp
 /doc
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.8.4
+
+* Enhancements
+  * Add json support
+  * Add unix socket support
+
 # 0.8.3
 
 * Enhancements

--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -65,6 +65,8 @@ defmodule Mariaex do
      if not `DBConnection.Connection` (default: `DBConnection.Connection`);
     * `:name` - A name to register the started process (see the `:name` option
     in `GenServer.start_link/3`).
+    * `:prepare` - How to prepare queries, either `:named` to use named queries
+      or `:unnamed` to force unnamed queries (default: `:named`);
 
   ## Function signatures
 
@@ -186,10 +188,10 @@ defmodule Mariaex do
       :text ->
         query = %Query{type: :text, name: name, statement: statement,
                        ref: make_ref(), num_params: 0}
-        {:ok, query}
+        {:ok, Mariaex.Protocol.sanitize_query(query, conn)}
       type when type in [:binary, nil] ->
         query = %Query{type: type, name: name, statement: statement}
-        prepare_binary(conn, query, opts)
+        prepare_binary(conn, Mariaex.Protocol.sanitize_query(query, conn), opts)
     end
   end
 

--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -188,10 +188,10 @@ defmodule Mariaex do
       :text ->
         query = %Query{type: :text, name: name, statement: statement,
                        ref: make_ref(), num_params: 0}
-        {:ok, Mariaex.Protocol.sanitize_query(query, conn)}
+        {:ok, query}
       type when type in [:binary, nil] ->
         query = %Query{type: type, name: name, statement: statement}
-        prepare_binary(conn, Mariaex.Protocol.sanitize_query(query, conn), opts)
+        prepare_binary(conn, query, opts)
     end
   end
 

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -318,18 +318,18 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  def sanitize_query(query, conn) when is_pid(conn) do
+  defp sanitize_query(query, conn) when is_pid(conn) do
     {:ok, pool_ref, _mod, state} = DBConnection.Connection.checkout(conn, [])
     DBConnection.Connection.checkin(pool_ref, state, [])
     sanitize_query(query, state)
   end
-  def sanitize_query(query, %{opts: opts}) do
+  defp sanitize_query(query, %{opts: opts}) do
     case Keyword.get(opts, :prepare, :named) do
       :unnamed -> %Query{query | name: "_unnamed_"}
       :named -> query
     end
   end
-  def sanitize_query(query, _state), do: query
+  defp sanitize_query(query, _state), do: query
 
   @doc """
   DBConnection callback

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -318,18 +318,12 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp sanitize_query(query, conn) when is_pid(conn) do
-    {:ok, pool_ref, _mod, state} = DBConnection.Connection.checkout(conn, [])
-    DBConnection.Connection.checkin(pool_ref, state, [])
-    sanitize_query(query, state)
-  end
   defp sanitize_query(query, %{opts: opts}) do
     case Keyword.get(opts, :prepare, :named) do
       :unnamed -> %Query{query | name: "_unnamed_"}
       :named -> query
     end
   end
-  defp sanitize_query(query, _state), do: query
 
   @doc """
   DBConnection callback
@@ -458,7 +452,6 @@ defmodule Mariaex.Protocol do
     send_text_query(state, statement) |> text_query_recv(query)
   end
   def handle_execute(%Query{type: :binary} = query, params, _, state) do
-    query = sanitize_query(query, state)
     case execute_lookup(query, state) do
       {:execute, id, query} ->
         execute(id, query, params, state)

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -135,7 +135,7 @@ defmodule Mariaex.Protocol do
   end
 
   defp parse_host(host) do
-    host = if is_binary(host), do: String.to_char_list(host), else: host
+    host = if is_binary(host), do: String.to_charlist(host), else: host
 
     case :inet.parse_strict_address(host) do
       {:ok, address} ->
@@ -1031,7 +1031,7 @@ defmodule Mariaex.Protocol do
     l |> Enum.map(&bxor(&1, extra - 64)) |> to_string
   end
 
-  defp hash(bin) when is_binary(bin), do: bin |> to_char_list |> hash
+  defp hash(bin) when is_binary(bin), do: bin |> to_charlist |> hash
   defp hash(s), do: hash(s, 1345345333, 305419889, 7)
   defp hash([c | s], n1, n2, add) do
     n1 = bxor(n1, (((band(n1, 63) + add) * c + n1 * 256)))

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Mariaex.Mixfile do
 
   def project do
     [app: :mariaex,
-     version: "0.8.3",
+     version: "0.8.4",
      elixir: "~> 1.2",
      deps: deps(),
      name: "Mariaex",

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -2,8 +2,9 @@ defmodule PreparedQueryTest do
   use ExUnit.Case
   import Mariaex.TestHelper
 
-  setup do
+  setup context do
     opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
+    opts = opts ++ (context |> Map.to_list() |> Keyword.take([:prepare]))
     {:ok, pid} = Mariaex.Connection.start_link(opts)
     {:ok, [pid: pid]}
   end
@@ -21,14 +22,34 @@ defmodule PreparedQueryTest do
   end
 
   test "prepare, execute and close", context do
-    assert (%Mariaex.Query{} = query) = prepare("42", "SELECT 42")
+    assert (%Mariaex.Query{name: "42"} = query) = prepare("42", "SELECT 42")
     assert [[42]] = execute(query, [])
     assert [[42]] = execute(query, [])
     assert :ok = close(query)
     assert [[42]] = query("SELECT 42", [])
   end
 
-  test "prepare query and execute different queries with same name", context do
+  @tag prepare: :unnamed
+  test "prepare named is unnamed when named not allowed", context do
+    assert (%Mariaex.Query{name: "_unnamed_"} = query) = prepare("42", "SELECT 42")
+    assert [[42]] = execute(query, [])
+    assert [[42]] = execute(query, [])
+    assert :ok = close(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag prepare: :unnamed
+  test "stableized prepared statement count with prepare unnamed", context do
+    count = prepared() + 1
+    for _n <- 1..2 do
+      for n <- 1..10 do
+        assert [[^n]] = with_prepare!("#{n}", "SELECT #{n}", [])
+        assert ^count = prepared()
+      end
+    end
+  end
+
+  test "prepare and execute different queries with same name", context do
     query42 = prepare("select", "SELECT 42")
     assert close(query42) == :ok
     assert %Mariaex.Query{} = prepare("select", "SELECT 41")

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -31,7 +31,7 @@ defmodule PreparedQueryTest do
 
   @tag prepare: :unnamed
   test "prepare named is unnamed when named not allowed", context do
-    assert (%Mariaex.Query{name: "_unnamed_"} = query) = prepare("42", "SELECT 42")
+    assert (%Mariaex.Query{name: ""} = query) = prepare("42", "SELECT 42")
     assert [[42]] = execute(query, [])
     assert [[42]] = execute(query, [])
     assert :ok = close(query)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -35,14 +35,12 @@ sql = """
 cmds = [
   ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
   ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci';"),
-  ~s(mysql #{mysql_connect} -e "CREATE USER 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass';"),
-  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' WITH GRANT OPTION"),
+  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass' WITH GRANT OPTION;"),
   ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=tcp -u mariaex_user -pmariaex_pass mariaex_test -e "#{sql}")
 ]
 
 Enum.each(cmds, fn cmd ->
   {status, output} = run_cmd.(cmd)
-  IO.puts "--> #{output}"
 
   if status != 0 do
     IO.puts """

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -35,12 +35,14 @@ sql = """
 cmds = [
   ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
   ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci';"),
-  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass' WITH GRANT OPTION;"),
+  ~s(mysql #{mysql_connect} -e "CREATE USER 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass';"),
+  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' WITH GRANT OPTION"),
   ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=tcp -u mariaex_user -pmariaex_pass mariaex_test -e "#{sql}")
 ]
 
 Enum.each(cmds, fn cmd ->
   {status, output} = run_cmd.(cmd)
+  IO.puts "--> #{output}"
 
   if status != 0 do
     IO.puts """

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -101,6 +101,13 @@ defmodule Mariaex.TestHelper do
     end
   end
 
+  defmacro prepared do
+    quote do
+      [[_name, count]] = execute_text("SHOW GLOBAL STATUS LIKE '%Prepared_stmt_count%'", [])
+      String.to_integer(count)
+    end
+  end
+
   defmacro execute(query, params, opts \\ []) do
     quote do
       case Mariaex.execute(var!(context)[:pid], unquote(query), unquote(params),


### PR DESCRIPTION
This is similar to Postgrex (0.14.0-rc.1) so the prepare option is either `:named` (default) or `:unnamed` in which `:unnamed` forces the name of the prepared statement to be `""`.

The corresponding Travis CI build: https://travis-ci.org/bettyblocks/mariaex/builds/448281333
This pull request should comply to: https://github.com/xerions/mariaex/issues/182#issuecomment-337810317