### PR TITLE
Reduce amount of prepared statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ erl_crash.dump
 .compile.elixir
 *.swp
 /doc
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 .compile.elixir
 *.swp
 /doc
+.DS_Store

--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -70,6 +70,8 @@ defmodule Mariaex do
     in `GenServer.start_link/3`).
     * `:datetime` - How datetimes should be returned. `:structs` for Elixir v1.3
       calendar types or `:tuples` for the backwards compatible tuples
+    * `:prepare` - How to prepare queries, either `:named` to use named queries
+      or `:unnamed` to force unnamed queries (default: `:named`);
 
   ## Function signatures
 
@@ -188,10 +190,10 @@ defmodule Mariaex do
       :text ->
         query = %Query{type: :text, name: name, statement: statement,
                        ref: make_ref(), num_params: 0}
-        {:ok, query}
+        {:ok, Mariaex.Protocol.sanitize_query(query, conn)}
       type when type in [:binary, nil] ->
         query = %Query{type: type, name: name, statement: statement}
-        DBConnection.prepare(conn, query, opts)
+        DBConnection.prepare(conn, Mariaex.Protocol.sanitize_query(query, conn), opts)
     end
   end
 

--- a/lib/mariaex.ex
+++ b/lib/mariaex.ex
@@ -190,10 +190,10 @@ defmodule Mariaex do
       :text ->
         query = %Query{type: :text, name: name, statement: statement,
                        ref: make_ref(), num_params: 0}
-        {:ok, Mariaex.Protocol.sanitize_query(query, conn)}
+        {:ok, query}
       type when type in [:binary, nil] ->
         query = %Query{type: type, name: name, statement: statement}
-        DBConnection.prepare(conn, Mariaex.Protocol.sanitize_query(query, conn), opts)
+        DBConnection.prepare(conn, query, opts)
     end
   end
 

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -323,18 +323,12 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp sanitize_query(query, conn) when is_pid(conn) do
-    {:ok, pool_ref, _mod, state} = DBConnection.Holder.checkout(conn, [])
-    DBConnection.Holder.checkin(pool_ref)
-    sanitize_query(query, state)
-  end
   defp sanitize_query(query, %{opts: opts}) do
     case Keyword.get(opts, :prepare, :named) do
       :unnamed -> %Query{query | name: "_unnamed_"}
       :named -> query
     end
   end
-  defp sanitize_query(query, _state), do: query
 
   @doc """
   DBConnection callback
@@ -457,7 +451,6 @@ defmodule Mariaex.Protocol do
     send_text_query(state, statement) |> text_query_recv(opts, query)
   end
   def handle_execute(%Query{type: :binary} = query, params, opts, state) do
-    query = sanitize_query(query, state)
     case execute_lookup(query, state) do
       {:execute, id, query} ->
         execute(id, query, params, state, opts)

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -323,6 +323,19 @@ defmodule Mariaex.Protocol do
     end
   end
 
+  def sanitize_query(query, conn) when is_pid(conn) do
+    {:ok, pool_ref, _mod, state} = DBConnection.Holder.checkout(conn, [])
+    DBConnection.Holder.checkin(pool_ref)
+    sanitize_query(query, state)
+  end
+  def sanitize_query(query, %{opts: opts}) do
+    case Keyword.get(opts, :prepare, :named) do
+      :unnamed -> %Query{query | name: "_unnamed_"}
+      :named -> query
+    end
+  end
+  def sanitize_query(query, _state), do: query
+
   @doc """
   DBConnection callback
   """
@@ -335,6 +348,7 @@ defmodule Mariaex.Protocol do
     end
   end
   def handle_prepare(%Query{type: :binary} = query, opts, %{binary_as: binary_as} = s) do
+    query = sanitize_query(query, s)
     case prepare_lookup(%Query{query | binary_as: binary_as}, s) do
       {:prepared, query} ->
         {:ok, query, s}
@@ -443,6 +457,7 @@ defmodule Mariaex.Protocol do
     send_text_query(state, statement) |> text_query_recv(opts, query)
   end
   def handle_execute(%Query{type: :binary} = query, params, opts, state) do
+    query = sanitize_query(query, state)
     case execute_lookup(query, state) do
       {:execute, id, query} ->
         execute(id, query, params, state, opts)

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -16,6 +16,7 @@ defmodule Mariaex.Protocol do
   @cache_size 100
   @max_rows 500
   @nonposix_errors [:closed, :timeout]
+  @unnamed :unnamed
 
   @maxpacketbytes 50000000
   @mysql_native_password "mysql_native_password"
@@ -100,6 +101,7 @@ defmodule Mariaex.Protocol do
                         datetime: datetime,
                         json_library: json_library,
                         opts: opts}
+        s = if unnamed?(opts), do: Map.delete(s, :lru_cache), else: s
         handshake_recv(s, %{opts: opts})
       {:error, reason} ->
         {:error, %Mariaex.Error{message: "tcp connect: #{reason}"}}
@@ -157,6 +159,9 @@ defmodule Mariaex.Protocol do
       :not_used
     end
   end
+
+  defp unnamed?(%{opts: opts}), do: unnamed?(opts)
+  defp unnamed?(opts), do: Keyword.get(opts, :prepare) == @unnamed
 
   defp has_ssl_opts?(nil), do: false
   defp has_ssl_opts?([]), do: false
@@ -323,13 +328,6 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp sanitize_query(query, %{opts: opts}) do
-    case Keyword.get(opts, :prepare, :named) do
-      :unnamed -> %Query{query | name: "_unnamed_"}
-      :named -> query
-    end
-  end
-
   @doc """
   DBConnection callback
   """
@@ -342,7 +340,7 @@ defmodule Mariaex.Protocol do
     end
   end
   def handle_prepare(%Query{type: :binary} = query, opts, %{binary_as: binary_as} = s) do
-    query = sanitize_query(query, s)
+    query = if unnamed?(s), do: %Query{query | name: ""}, else: query
     case prepare_lookup(%Query{query | binary_as: binary_as}, s) do
       {:prepared, query} ->
         {:ok, query, s}

--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -323,18 +323,18 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  def sanitize_query(query, conn) when is_pid(conn) do
+  defp sanitize_query(query, conn) when is_pid(conn) do
     {:ok, pool_ref, _mod, state} = DBConnection.Holder.checkout(conn, [])
     DBConnection.Holder.checkin(pool_ref)
     sanitize_query(query, state)
   end
-  def sanitize_query(query, %{opts: opts}) do
+  defp sanitize_query(query, %{opts: opts}) do
     case Keyword.get(opts, :prepare, :named) do
       :unnamed -> %Query{query | name: "_unnamed_"}
       :named -> query
     end
   end
-  def sanitize_query(query, _state), do: query
+  defp sanitize_query(query, _state), do: query
 
   @doc """
   DBConnection callback

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -38,7 +38,7 @@ defmodule PreparedQueryTest do
 
   @tag prepare: :unnamed
   test "prepare named is unnamed when named not allowed", context do
-    assert (%Mariaex.Query{name: "_unnamed_"} = query) = prepare("42", "SELECT 42")
+    assert (%Mariaex.Query{name: ""} = query) = prepare("42", "SELECT 42")
     assert [[42]] = execute(query, [])
     assert [[42]] = execute(query, [])
     assert :ok = close(query)

--- a/test/prepared_query_test.exs
+++ b/test/prepared_query_test.exs
@@ -2,8 +2,9 @@ defmodule PreparedQueryTest do
   use ExUnit.Case
   import Mariaex.TestHelper
 
-  setup do
+  setup context do
     opts = [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", backoff_type: :stop]
+    opts = opts ++ (context |> Map.to_list() |> Keyword.take([:prepare]))
     {:ok, pid} = Mariaex.Connection.start_link(opts)
     {:ok, [pid: pid]}
   end
@@ -21,7 +22,7 @@ defmodule PreparedQueryTest do
   end
 
   test "prepare, execute and close", context do
-    assert (%Mariaex.Query{} = query) = prepare("42", "SELECT 42")
+    assert (%Mariaex.Query{name: "42"} = query) = prepare("42", "SELECT 42")
     assert [[42]] = execute(query, [])
     assert [[42]] = execute(query, [])
     assert :ok = close(query)
@@ -33,6 +34,26 @@ defmodule PreparedQueryTest do
     assert [[41]] = execute(query, [41])
     assert :ok = close(query)
     assert [[43]] = query("SELECT ?", [43])
+  end
+
+  @tag prepare: :unnamed
+  test "prepare named is unnamed when named not allowed", context do
+    assert (%Mariaex.Query{name: "_unnamed_"} = query) = prepare("42", "SELECT 42")
+    assert [[42]] = execute(query, [])
+    assert [[42]] = execute(query, [])
+    assert :ok = close(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag prepare: :unnamed
+  test "stableized prepared statement count with prepare unnamed", context do
+    count = prepared() + 1
+    for _n <- 1..2 do
+      for n <- 1..10 do
+        assert [[^n]] = with_prepare!("#{n}", "SELECT #{n}", [])
+        assert ^count = prepared()
+      end
+    end
   end
 
   test "prepare and execute different queries with same name", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -56,10 +56,17 @@ sql = """
   DROP TABLE test1;
 """
 
+create_user =
+  case System.get_env("DB") do
+    "mysql:5.6" -> "CREATE USER"
+    _ -> "CREATE USER IF NOT EXISTS"
+  end
+
 cmds = [
   ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
   ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci';"),
-  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass' WITH GRANT OPTION;"),
+  ~s(mysql #{mysql_connect} -e "#{create_user} 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass';"),
+  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' WITH GRANT OPTION"),
   ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=tcp -u mariaex_user -pmariaex_pass mariaex_test -e "#{
     sql
   }")
@@ -67,6 +74,7 @@ cmds = [
 
 Enum.each(cmds, fn cmd ->
   {status, output} = run_cmd.(cmd)
+  IO.puts("--> #{output}")
 
   if status != 0 do
     IO.puts("""

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -56,17 +56,10 @@ sql = """
   DROP TABLE test1;
 """
 
-create_user =
-  case System.get_env("DB") do
-    "mysql:5.6" -> "CREATE USER"
-    _ -> "CREATE USER IF NOT EXISTS"
-  end
-
 cmds = [
   ~s(mysql #{mysql_connect} -e "DROP DATABASE IF EXISTS mariaex_test;"),
   ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci';"),
-  ~s(mysql #{mysql_connect} -e "#{create_user} 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass';"),
-  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' WITH GRANT OPTION"),
+  ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass' WITH GRANT OPTION;"),
   ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=tcp -u mariaex_user -pmariaex_pass mariaex_test -e "#{
     sql
   }")
@@ -74,7 +67,6 @@ cmds = [
 
 Enum.each(cmds, fn cmd ->
   {status, output} = run_cmd.(cmd)
-  IO.puts("--> #{output}")
 
   if status != 0 do
     IO.puts("""

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -131,6 +131,13 @@ defmodule Mariaex.TestHelper do
     end
   end
 
+  defmacro prepared do
+    quote do
+      [[_name, count]] = execute_text("SHOW GLOBAL STATUS LIKE '%Prepared_stmt_count%'", [])
+      String.to_integer(count)
+    end
+  end
+
   defmacro execute(query, params, opts \\ []) do
     quote do
       case Mariaex.execute(var!(context)[:pid], unquote(query), unquote(params), unquote(opts)) do


### PR DESCRIPTION
This is similar to Postgrex (0.14.0-rc.1) so the prepare option is either `:named` (default) or `:unnamed` in which `:unnamed` forces the name of the prepared statement to be `""`.

The corresponding Travis CI build: https://travis-ci.org/bettyblocks/mariaex/builds/448283254
This pull request should comply to: https://github.com/xerions/mariaex/issues/182#issuecomment-337810317