### PR TITLE
Handle error when "query" is of shape `%{opts: opts}`. Should fix #250.

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -1291,6 +1291,8 @@ defmodule Mariaex.Protocol do
         {:error, error, clean_state(s, nil)}
       nil ->
         {:error, error, clean_state(s, nil)}
+      %{opts: _opts} ->
+        {:error, error, clean_state(s, nil)}
     end
   end
 end

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -1,0 +1,46 @@
+defmodule ConnectionTest do
+  use ExUnit.Case
+  import Mariaex.TestHelper
+
+  @opts [
+    database: "mariaex_test",
+    username: "mariaex_user",
+    password: "mariaex_pass",
+    cache_size: 2,
+    max_restarts: 0
+  ]
+
+  setup context do
+    connection_opts = context[:connection_opts] || []
+    {:ok, pid} = Mariaex.Connection.start_link(connection_opts ++ @opts)
+
+    # remove all modes for this session to have the same behaviour on different versions of mysql/mariadb
+    {:ok, _} = Mariaex.Connection.query(pid, "SET SESSION sql_mode = \"\";")
+
+    {:ok, _} = Mariaex.Connection.query(pid, "set GLOBAL max_connections = 1;")
+
+    {:ok, [pid: pid]}
+  end
+
+  test "query fails with connection not available", %{pid: orig_pid} do
+    # my version of mariadb only allows setting max_connections to 10, so we have to start up a few connections to saturate this.
+    assert Enum.find(1..15, fn _x ->
+             {:ok, pid} = Mariaex.Connection.start_link(@opts)
+             context = [pid: pid]
+
+             case query("SELECT 1", []) do
+               [[1]] ->
+                 false
+
+               %DBConnection.ConnectionError{
+                 message:
+                   "connection not available and request was dropped from queue after " <> rest
+               } ->
+                 true
+             end
+           end)
+
+    # cleanup
+    {:ok, _} = Mariaex.Connection.query(orig_pid, "set GLOBAL max_connections = 500;")
+  end
+end


### PR DESCRIPTION
Here is my commentary from #250, to give some context:
> I have looked at the code to try to understand what is going on here. handshake_recv/2 is called like so on line 103: handshake_recv(s, %{opts: opts})
Then on line 171 this %{opts: opts} gets sent to handle_handshake/3 as second parameter.
There are three function heads for handle_handshake/3. As far as I can see it's supposed to come out to the one first one, defined on line 202, but it ends up in the third one, defined on line 231.

> This is where I lose the plot a little bit, but the case statement on line 1245 is not set up to handle %{opts: opts}, so it crashes.

> I can't tell if it's supposed to get to handle_handshake/3 on line 231. Possibly the answer is yes (?). If it is supposed to be able to get there, then there needs to be a case clause added to abort_statement to handle %{opts: opts} as query.

Please advise if there is any additional cleanup that needs to happen. My gut says that there isn't, but I'm also not very familiar with the mariaex internals.