### PR TITLE
fix not applying :timeout in query options

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -231,7 +231,7 @@ defmodule Mariaex.Protocol do
   defp handle_handshake(packet(msg: ok_resp(affected_rows: _affected_rows, last_insert_id: _last_insert_id) = _packet), nil, state) do
     statement = "SET CHARACTER SET " <> (state.opts[:charset] || "utf8")
     query = %Query{type: :text, statement: statement}
-    case send_text_query(state, statement) |> text_query_recv(query) do
+    case send_text_query(state, statement) |> text_query_recv([], query) do
       {:error, error, _} ->
         {:error, error}
       {:ok, _, state} ->
@@ -362,15 +362,15 @@ defmodule Mariaex.Protocol do
         other
     end
   end
-  def handle_prepare(%Query{type: :binary} = query, _, s) do
+  def handle_prepare(%Query{type: :binary} = query, opts, s) do
     query = if unnamed?(s), do: %Query{query | name: ""}, else: query
     case prepare_lookup(%Query{query | binary_as: s.binary_as}, s) do
       {:prepared, query} ->
         {:ok, query, s}
       {:prepare, query} ->
-        prepare(query, s)
+        prepare(opts, query, s)
       {:close_prepare, id, query} ->
-        close_prepare(id, query, s)
+        close_prepare(id, opts, query, s)
     end
   end
   def handle_prepare(%Query{type: _} = query, _, s) do
@@ -397,20 +397,20 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp prepare(%Query{statement: statement} = query, s) do
+  defp prepare(opts, %Query{statement: statement} = query, s) do
     msg_send(text_cmd(command: com_stmt_prepare(), statement: statement), s, 0)
-    prepare_recv(%{s | state: :prepare_send}, query)
+    prepare_recv(%{s | state: :prepare_send}, opts, query)
   end
 
-  defp close_prepare(id, %Query{statement: statement} = query, s) do
+  defp close_prepare(id, opts, %Query{statement: statement} = query, s) do
     msgs = [stmt_close(command: com_stmt_close(), statement_id: id),
             text_cmd(command: com_stmt_prepare(), statement: statement)]
     msg_send(msgs, s, 0)
-    prepare_recv(s, query)
+    prepare_recv(s, opts, query)
   end
 
-  defp prepare_recv(state, query) do
-    case prepare_recv(state) do
+  defp prepare_recv(state, opts, query) do
+    case prepare_recv(state, opts) do
       {:prepared, id, num_params, state} ->
         {:ok, prepare_insert(id, num_params, query, state), clean_state(state)}
       {:ok, packet, state} ->
@@ -420,33 +420,33 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp prepare_recv(state) do
+  defp prepare_recv(state, opts) do
     state = %{state | state: :prepare_send}
-    with {:ok, packet(msg: stmt_prepare_ok(statement_id: id, num_columns: num_cols, num_params: num_params)), state} <- msg_recv(state),
-         {:eof, state} <- skip_definitions(state, num_params),
-         {:eof, state} <- skip_definitions(state, num_cols) do
+    with {:ok, packet(msg: stmt_prepare_ok(statement_id: id, num_columns: num_cols, num_params: num_params)), state} <- msg_recv(state, opts),
+         {:eof, state} <- skip_definitions(state, opts, num_params),
+         {:eof, state} <- skip_definitions(state, opts, num_cols) do
       {:prepared, id, num_params, state}
     end
   end
 
-  defp skip_definitions(state, 0), do: {:eof, state}
-  defp skip_definitions(state, count) do
-    do_skip_definitions(%{state | state: :column_definitions}, count)
+  defp skip_definitions(state, opts, 0), do: {:eof, state}
+  defp skip_definitions(state, opts, count) do
+    do_skip_definitions(%{state | state: :column_definitions}, opts, count)
   end
 
-  defp do_skip_definitions(state, rem) when rem > 0 do
-    case msg_recv(state) do
+  defp do_skip_definitions(state, opts, rem) when rem > 0 do
+    case msg_recv(state, opts) do
       {:ok, packet(msg: column_definition_41()), state} ->
-        do_skip_definitions(state, rem-1)
+        do_skip_definitions(state, opts, rem-1)
       other ->
         other
     end
   end
-  defp do_skip_definitions(%{deprecated_eof: true} = state, 0) do
+  defp do_skip_definitions(%{deprecated_eof: true} = state, opts, 0) do
     {:eof, state}
   end
-  defp do_skip_definitions(%{deprecated_eof: false} = state, 0) do
-    case msg_recv(state) do
+  defp do_skip_definitions(%{deprecated_eof: false} = state, opts, 0) do
+    case msg_recv(state, opts) do
       {:ok, packet(msg: eof_resp()), state} ->
         {:eof, state}
       other ->
@@ -471,17 +471,17 @@ defmodule Mariaex.Protocol do
   def handle_execute(%Query{name: @reserved_prefix <> _, reserved?: false} = query, _, s) do
     reserved_error(query, s)
   end
-  def handle_execute(%Query{type: :text, statement: statement} = query, [], _opts, state) do
-    send_text_query(state, statement) |> text_query_recv(query)
+  def handle_execute(%Query{type: :text, statement: statement} = query, [], opts, state) do
+    send_text_query(state, statement) |> text_query_recv(opts, query)
   end
-  def handle_execute(%Query{type: :binary} = query, params, _, state) do
+  def handle_execute(%Query{type: :binary} = query, params, opts, state) do
     case execute_lookup(query, state) do
       {:execute, id, query} ->
-        execute(id, query, params, state)
+        execute(id, query, params, state, opts)
       {:prepare_execute, query} ->
-        prepare_execute(&prepare(query, &1), params, state)
+        prepare_execute(&prepare(opts, query, &1), params, state, opts)
       {:close_prepare_execute, id, query} ->
-        prepare_execute(&close_prepare(id, query, &1), params, state)
+        prepare_execute(&close_prepare(id, opts, query, &1), params, state, opts)
     end
   end
 
@@ -511,16 +511,16 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp execute(id, query, params, state) do
+  defp execute(id, query, params, state, opts) do
     msg_send(stmt_execute(command: com_stmt_execute(), parameters: params, statement_id: id, flags: @cursor_type_no_cursor, iteration_count: 1), state, 0)
-    binary_query_recv(state, query)
+    binary_query_recv(state, opts, query)
   end
 
-  defp prepare_execute(prepare, params, state) do
+  defp prepare_execute(prepare, params, state, opts) do
     case prepare.(state) do
       {:ok, query, state} ->
         id = prepare_execute_lookup(query, state)
-        execute(id, query, params, state)
+        execute(id, query, params, state, opts)
       {err, _, _} = error when err in [:error, :disconnect] ->
         error
     end
@@ -533,8 +533,8 @@ defmodule Mariaex.Protocol do
     Cache.id(cache, name)
   end
 
-  defp text_query_recv(state, query) do
-    case text_query_recv(state) do
+  defp text_query_recv(state, opts, query) do
+    case text_query_recv(state, opts) do
       {:resultset, columns, rows, _flags, state} ->
         result = %Mariaex.Result{rows: rows, connection_id: state.connection_id}
         {:ok, {result, columns}, clean_state(state)}
@@ -547,10 +547,10 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp text_query_recv(state) do
+  defp text_query_recv(state, opts) do
     state = %{state | state: :column_count}
-    with {:ok, packet(msg: column_count(column_count: num_cols)), state} <- msg_recv(state),
-         {:eof, columns, _, state} <- columns_recv(state, num_cols),
+    with {:ok, packet(msg: column_count(column_count: num_cols)), state} <- msg_recv(state, opts),
+         {:eof, columns, _, state} <- columns_recv(state, opts, num_cols),
          {:eof, rows, flags, state} <- text_rows_recv(state, columns) do
       {:resultset, columns, rows, flags, state}
     end
@@ -593,10 +593,10 @@ defmodule Mariaex.Protocol do
     abort_statement(state, query, code, message)
   end
 
-  defp binary_query_recv(state, query) do
-    case binary_query_recv(state) do
+  defp binary_query_recv(state, opts, query) do
+    case binary_query_recv(state, opts) do
       {:resultset, columns, bin_rows, flags, state} ->
-        binary_query_resultset(state, query, columns, bin_rows, flags)
+        binary_query_resultset(state, opts, query, columns, bin_rows, flags)
       {:ok, packet(msg: ok_resp()) = packet, state} ->
         handle_ok_packet(packet, query, state)
       {:ok, packet, state} ->
@@ -606,33 +606,33 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp binary_query_recv(state) do
+  defp binary_query_recv(state, opts) do
     state = %{state | state: :column_count}
-    with {:ok, packet(msg: column_count(column_count: num_cols)), state} <- msg_recv(state),
-         {:eof, columns, _, state} <- columns_recv(state, num_cols),
+    with {:ok, packet(msg: column_count(column_count: num_cols)), state} <- msg_recv(state, opts),
+         {:eof, columns, _, state} <- columns_recv(state, opts, num_cols),
          {:eof, rows, flags, state} <- bin_rows_recv(state, columns) do
       {:resultset, columns, rows, flags, state}
     end
   end
 
-  defp columns_recv(state, num_cols) do
-    columns_recv(%{state | state: :column_definitions}, num_cols, [])
+  defp columns_recv(state, opts, num_cols) do
+    columns_recv(%{state | state: :column_definitions}, opts, num_cols, [])
   end
 
-  defp columns_recv(state, rem, columns) when rem > 0 do
-    case msg_recv(state) do
+  defp columns_recv(state, opts, rem, columns) when rem > 0 do
+    case msg_recv(state, opts) do
       {:ok, packet(msg: column_definition_41(type: type, name: name, flags: flags, table: table)), state} ->
         column = %Column{name: name, table: table, type: type, flags: flags}
-        columns_recv(state, rem-1, [column | columns])
+        columns_recv(state, opts, rem-1, [column | columns])
       other ->
         other
     end
   end
-  defp columns_recv(%{deprecated_eof: true} = state, 0, columns) do
+  defp columns_recv(%{deprecated_eof: true} = state, opts, 0, columns) do
     {:eof, Enum.reverse(columns), 0, state}
   end
-  defp columns_recv(%{deprecated_eof: false} = state, 0, columns) do
-    case msg_recv(state) do
+  defp columns_recv(%{deprecated_eof: false} = state, opts, 0, columns) do
+    case msg_recv(state, opts) do
       {:ok, packet(msg: eof_resp(status_flags: flags)), state} ->
         {:eof, Enum.reverse(columns), flags, state}
       other ->
@@ -652,18 +652,18 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp binary_query_resultset(state, query, columns, rows, flags) do
+  defp binary_query_resultset(state, opts, query, columns, rows, flags) do
     cond do
       (flags &&& @server_more_results_exists) == @server_more_results_exists ->
-        binary_query_more(state, query, columns, rows)
+        binary_query_more(state, opts, query, columns, rows)
       true ->
         result = %Mariaex.Result{rows: rows, connection_id: state.connection_id}
         {:ok, {result, columns}, clean_state(state)}
     end
   end
 
-  defp binary_query_more(state, query, columns, rows) do
-    case msg_recv(state) do
+  defp binary_query_more(state, opts, query, columns, rows) do
+    case msg_recv(state, opts) do
       {:ok, packet(msg: ok_resp(affected_rows: affected_rows, last_insert_id: last_insert_id)), state} ->
         result = %Mariaex.Result{rows: rows, num_rows: affected_rows,
           last_insert_id: last_insert_id, connection_id: state.connection_id}
@@ -747,9 +747,9 @@ defmodule Mariaex.Protocol do
       {:declare, id} ->
         declare(id, params, opts, state)
       {:prepare_declare, query} ->
-        prepare_declare(&prepare(query, &1), params, opts, state)
+        prepare_declare(&prepare(opts, query, &1), params, opts, state)
       {:close_prepare_declare, id, query} ->
-        prepare_declare(&close_prepare(id, query, &1), params, opts, state)
+        prepare_declare(&close_prepare(id, opts, query, &1), params, opts, state)
       {:text, _} ->
         cursor = %Cursor{statement_id: :text, params: params, ref: make_ref()}
         {:ok, cursor, state}
@@ -809,17 +809,17 @@ defmodule Mariaex.Protocol do
         other
     end
   end
-  def handle_first(query, %Cursor{statement_id: id, ref: ref, params: params}, _, state) do
+  def handle_first(query, %Cursor{statement_id: id, ref: ref, params: params}, opts, state) do
     msg_send(stmt_execute(command: com_stmt_execute(), parameters: params, statement_id: id, flags: @cursor_type_read_only, iteration_count: 1), state, 0)
-    binary_first_recv(state, ref, query)
+    binary_first_recv(state, opts, ref, query)
   end
 
-  defp binary_first_recv(state, ref, query) do
-    case binary_first_recv(state) do
+  defp binary_first_recv(state, opts, ref, query) do
+    case binary_first_recv(state, opts) do
       {:eof, columns, flags, state} ->
-        binary_first_resultset(state, query, ref, columns, [], flags)
+        binary_first_resultset(state, opts, query, ref, columns, [], flags)
       {:resultset, columns, rows, flags, state} ->
-        binary_first_resultset(state, query, ref, columns, rows, flags)
+        binary_first_resultset(state, opts, query, ref, columns, rows, flags)
       {:ok, packet(msg: ok_resp()) = packet, state} ->
         {:ok, result, state} = handle_ok_packet(packet, query, state)
         {:deallocate, result, state}
@@ -830,19 +830,19 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp binary_first_recv(state) do
+  defp binary_first_recv(state, opts) do
     state = %{state | state: :column_count}
-    with {:ok, packet(msg: column_count(column_count: num_cols)), state} <- msg_recv(state),
-         {:eof, columns, flags, state} when (flags &&& @server_status_cursor_exists) == 0 <- columns_recv(state, num_cols),
+    with {:ok, packet(msg: column_count(column_count: num_cols)), state} <- msg_recv(state, opts),
+         {:eof, columns, flags, state} when (flags &&& @server_status_cursor_exists) == 0 <- columns_recv(state, opts, num_cols),
          {:eof, rows, flags, state} <- bin_rows_recv(state, columns) do
       {:resultset, columns, rows, flags, state}
     end
   end
 
-  defp binary_first_resultset(state, query, ref, columns, rows, flags) do
+  defp binary_first_resultset(state, opts, query, ref, columns, rows, flags) do
     cond do
       (flags &&& @server_more_results_exists) == @server_more_results_exists ->
-        binary_first_more(state, query, columns, rows)
+        binary_first_more(state, opts, query, columns, rows)
       (flags &&& @server_status_cursor_exists) == @server_status_cursor_exists ->
         %{cursors: cursors} = state
         state = clean_state(%{state | cursors: Map.put(cursors, ref, columns)})
@@ -852,8 +852,8 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  defp binary_first_more(state, query, columns, rows) do
-    case binary_query_more(state, query, columns, rows) do
+  defp binary_first_more(state, opts, query, columns, rows) do
+    case binary_query_more(state, opts, query, columns, rows) do
       {:ok, res, state} ->
         {:deallocate, res, state}
       other ->
@@ -1114,34 +1114,34 @@ defmodule Mariaex.Protocol do
     sock_mod.send(sock, data)
   end
 
-  defp msg_recv(%__MODULE__{sock: sock_info, buffer: buffer}=state) do
-    msg_recv(sock_info, state, buffer)
+  defp msg_recv(%__MODULE__{sock: sock_info, buffer: buffer}=state, opts \\ []) do
+    msg_recv(sock_info, state, opts[:timeout] || state.timeout, buffer)
   end
 
-  defp msg_recv(sock, state, buffer) do
+  defp msg_recv(sock, state, timeout, buffer) do
     case msg_decode(buffer, state) do
       {:ok, _packet, _new_state}=success ->
         success
 
       {:more, more} ->
-        msg_recv(sock, state, buffer, more)
+        msg_recv(sock, state, timeout, buffer, more)
 
       {:error, _}=err ->
         err
     end
   end
 
-  defp msg_recv({sock_mod, sock}=s, state, buffer, more) do
+  defp msg_recv({sock_mod, sock}=s, state, timeout, buffer, more) do
 
-    case sock_mod.recv(sock, more, state.timeout) do
+    case sock_mod.recv(sock, more, timeout) do
       {:ok, data} when byte_size(data) < more ->
-        msg_recv(s, state, [buffer | data], more - byte_size(data))
+        msg_recv(s, state, timeout, [buffer | data], more - byte_size(data))
 
       {:ok, data} when is_binary(buffer) ->
-        msg_recv(s, state, buffer <> data)
+        msg_recv(s, state, timeout, buffer <> data)
 
       {:ok, data} when is_list(buffer) ->
-        msg_recv(s, state, IO.iodata_to_binary([buffer | data]))
+        msg_recv(s, state, timeout, IO.iodata_to_binary([buffer | data]))
 
       {:error, _} = err ->
           err

--- a/test/timeout_test.exs
+++ b/test/timeout_test.exs
@@ -1,0 +1,33 @@
+defmodule TimeoutTest do
+  use ExUnit.Case, async: true
+  import Mariaex.TestHelper
+
+  @opts [database: "mariaex_test", username: "mariaex_user", password: "mariaex_pass", cache_size: 2, backoff_type: :stop, max_restarts: 0]
+
+  setup context do
+    connection_opts = context[:connection_opts] || []
+    {:ok, pid} = Mariaex.Connection.start_link(connection_opts ++ @opts)
+    # remove all modes for this session to have the same behaviour on different versions of mysql/mariadb
+    {:ok, _} = Mariaex.Connection.query(pid, "SET SESSION sql_mode = \"\";")
+    {:ok, [pid: pid]}
+  end
+
+  test "query failing with configured timeout" do
+    opts = [{:timeout, 500} | Keyword.take(@opts, [:database, :username, :password])]
+    {:ok, pid} = Mariaex.Connection.start_link(opts)
+
+    context = [pid: pid]
+
+    assert query("SELECT sleep(1)", []) == %DBConnection.ConnectionError{message: "tcp recv: timeout"}
+  end
+
+  test "query with timeout overwrite in options working" do
+    opts = [{:timeout, 500} | Keyword.take(@opts, [:database, :username, :password])]
+    {:ok, pid} = Mariaex.Connection.start_link(opts)
+
+    context = [pid: pid]
+
+    assert query("SELECT sleep(1)", [], timeout: 2000) == [[0]]
+  end
+
+end


### PR DESCRIPTION
The :timeout option parameter in DBConnection callbacks was not forwarded to
the message receiving function.
Instead the configured general :timeout was used.

Added two testcases which will block for ~1.5 seconds.

closes #162

(cherry picked from commit f48e99ba9f7afbcbfac011ebffa52b250f34367a)