### PR TITLE
Backport: Fix typespec rows as lists not tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After you are done, run `mix deps.get` in your shell to fetch and compile Mariae
   iex(5)> Mariaex.query(p, "SELECT id, title FROM test1")
   {:ok,
    %Mariaex.Result{columns: ["id", "title"], command: :select, num_rows: 2,
-    rows: [{1, "test"}, {2, "test2"}]}}
+    rows: [[1, "test"], [2, "test2"]}}
 ```
 
 ## Configuration

--- a/lib/mariaex/structs.ex
+++ b/lib/mariaex/structs.ex
@@ -5,14 +5,14 @@ defmodule Mariaex.Result do
     * `command` - An atom of the query command, for example: `:select` or
                   `:insert`;
     * `columns` - The column names;
-    * `rows` - The result set. A list of tuples, each tuple corresponding to a
-               row, each element in the tuple corresponds to a column;
+    * `rows` - The result set. A list of lists, each list corresponding to a
+               row, each element of the inner list corresponds to a column value;
     * `num_rows` - The number of fetched or affected rows;
   """
 
   @type t :: %__MODULE__{
     columns:  [String.t] | nil,
-    rows:     [tuple] | nil,
+    rows:     [[any]] | nil,
     last_insert_id: integer,
     num_rows: integer,
     connection_id: nil}


### PR DESCRIPTION
Looks like it was changed from tuples to lists in 0.4

Cherrypicked from https://github.com/xerions/mariaex/commit/d00bc7807746de33d6674d43fc9633c479a6f367

Sadly, it's difficult for me to upgrade mariaex to 0.9.1 because it requires I upgrade to db_connection 2.x which then requires I upgrade to ecto 3.x and the chain goes on to almost the entire project. Would you be willing to backport this fix and release it as v0.8.6 so I can get rid of the dialyzer errors without doing a full app upgrade?
